### PR TITLE
fix: corregir erratas en textos de la home (Fase A0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md — Reseñan Sancho (frontend)
+
+## Qué es esto
+Reseñan Sancho es una plataforma web que conecta escritores (mayoritariamente
+independientes) con reseñadores literarios. En esencia es un buscador doble:
+escritores buscan reseñadores, y reseñadores buscan libros, filtrando por
+género literario y formato. URL: https://www.resenansancho.com/
+
+Este repo es el FRONTEND. El backend (API) vive en un repo aparte.
+
+## Stack actual
+- Next.js 9.3.1, React ^16.13.0, TypeScript
+- Node 14 (¡desactualizado! ver plan de migración)
+- Integra la API de Mailchimp para registrar usuarios automáticamente
+- Despliegue: Heroku con auto-deploy desde la rama `master` de GitHub
+
+## Cómo arrancar y probar
+<!-- AJUSTA estos comandos a los reales de tu package.json -->
+- Instalar: `npm install`
+- Desarrollo: `npm run dev`
+- Build de producción: `npm run build`
+
+## Reglas de trabajo (IMPORTANTES)
+- NUNCA trabajar directo en `master`. Crear siempre una rama aparte.
+- `master` debe estar siempre sano: Heroku despliega automáticamente al
+  hacer merge a `master`.
+- Antes de proponer un merge a `master`, verificar a mano el flujo crítico:
+  registro/alta de usuario, alta de libro, modal de contacto (que el email
+  llegue), y un pago de prueba en Stripe (modo test).
+- Hacer commits pequeños y descriptivos.
+- NO commitear secretos (.env, claves de Stripe/Mailchimp/Mongo).
+
+## Convenciones
+- Idioma de la interfaz: español (con versión inglesa). Cuidar la ortografía
+  en textos de cara al público.
+- Paleta de marca: azul (#1E78B6 aprox.) y amarillo de acento; ver identidad
+  corporativa. Público objetivo: 16-25 años, mayoritariamente femenino;
+  el tono visual debe ser fresco, dinámico y cercano.
+
+## Plan de mejora
+Hay un plan de migración y rediseño por fases en `/docs/plan-mejora.md`.
+Resumen: modernizar Next.js (9 → 15) y rediseñar A LA VEZ, página por página,
+manteniendo la web viva. NO hacer un rewrite de golpe.
+
+### Estado actual
+- [x] Fase A0: corregir erratas de la home ("encotrar", "liteararios")
+- [ ] Fase A1: definir sistema de diseño
+- [ ] Fase A2: estabilizar en Next 15 + React 18 + Node LTS (router actual)
+- [ ] Fase A3: rediseñar home
+- (actualiza esta lista según avances)

--- a/public/static/locales/es/common.json
+++ b/public/static/locales/es/common.json
@@ -86,11 +86,11 @@
     "homeTwo": "No solo para dar a conocer nuestra novela sino para mejorar como escritores, las reseñas son una parte muy importante del proceso editorial.",
     "homeThree": "Por eso, Reseñan Sancho toma su nombre de la célebre frase: «Ladran, Sancho, señal que cabalgamos».",
     "homeFour": "Si tienes un blog literario, eres booktuber o bookstagramer, o simplemente te encanta escribir reseñas de los libros que lees, en goodreads o amazon, sabemos que siempre tendrás interés en descubrir a una escritora o escritor nuevos.",
-    "homeFive": "Crea tu cuenta para encotrar libros y conectar con sus autores. Ellos te lo agradecerán y estarán dispuestos a enviarte un ejemplar de su novela.",
+    "homeFive": "Crea tu cuenta para encontrar libros y conectar con sus autores. Ellos te lo agradecerán y estarán dispuestos a enviarte un ejemplar de su novela.",
     "homeSix": "Además, participarás en concursos de reseñas, propuestas de lecturas conjuntas y lanzamientos de libros en tu país.",
     "homeSeven": "La mejor forma de promocionar tu novela es que los demás hablen de ella.",
     "homeEight": "Una reseña literaria es un lector recomendándole a otros lectores un libro.",
-    "homeNine": "Si quieres empezar a dar a conocer tu obra, crea tu cuenta y empieza a ofrecer tu libro a cientos de reseñadores liteararios interesados en el género de tu novela."
+    "homeNine": "Si quieres empezar a dar a conocer tu obra, crea tu cuenta y empieza a ofrecer tu libro a cientos de reseñadores literarios interesados en el género de tu novela."
   },
   "components": {
     "countriesSelector": {


### PR DESCRIPTION
Corrección de dos erratas tipográficas en las traducciones al español:
- "encotrar" → "encontrar" (homeFive)
- "liteararios" → "literarios" (homeNine)