### PR TITLE
Redesign home footer with new design system

### DIFF
--- a/.claude/skills/regression-test-on-bugfix/SKILL.md
+++ b/.claude/skills/regression-test-on-bugfix/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: regression-test-on-bugfix
+description: >
+  Enforces that every bug fix ships with a regression test that fails before
+  the fix and passes after it, so the same bug can never silently come back.
+  Use this skill proactively whenever the work is a bug fix — when the user
+  says "fix this bug", "this is broken", "X doesn't work", "it crashes when…",
+  "regression", "it used to work", or whenever you are (or are about to be) on
+  a `bugfix/` branch. Applies to both the frontend (Next.js / React /
+  TypeScript, tested with Jest + React Testing Library) and the backend
+  (Node / Express / Mongoose, tested with Jest + supertest). Do NOT use it for
+  new features (`feature/`) or pure refactors with no behavioural bug — those
+  follow normal testing practice, not this fail-first regression rule.
+---
+
+# Regression test on every bug fix
+
+A bug that was fixed once and comes back is worse than a new bug: it means the
+fix was never protected. This skill makes the regression test a **required
+deliverable of the bug fix**, not an optional follow-up. No bug fix is "done"
+until a test reproduces the bug and now passes.
+
+This complements `git-workflow`: that skill puts you on a `bugfix/` branch;
+this one governs what must be inside that branch before it can merge to master.
+
+## The non-negotiable rule
+
+**Every bug fix must include at least one automated test that fails on the
+buggy code and passes on the fixed code.** The test asserts the *correct*
+behaviour for the exact input that triggered the bug.
+
+If you cannot write such a test, stop and say so explicitly before merging —
+do not quietly skip it. See "When a test is genuinely hard" below.
+
+## Workflow (fail-first)
+
+Follow this order. The point is to *prove* the test catches the bug, not just
+to add a test that happens to pass.
+
+### 1. Reproduce the bug as a failing test — before fixing the code
+
+Write the test first, against the current (broken) code, and run it. It **must
+fail**, and it must fail *because of this bug* (read the failure message and
+confirm it's the right failure, not a setup error). A test that passes against
+broken code proves nothing.
+
+Name the test after the observed behaviour, in English, e.g.
+`does not crash when synopsis is empty`, not `bug 123`. Code, names and
+comments stay in English; user-facing strings asserted in the test stay in
+Spanish, per the project convention.
+
+If a regression already references an issue/ticket, mention it in a comment
+(the *why*), not in the test name.
+
+### 2. Apply the fix
+
+Make the minimal change that fixes the bug. Don't fold unrelated refactors
+into the same step.
+
+### 3. Confirm the test now passes — and the rest still does
+
+Re-run the new test (now green) and then the **full suite** (`npm test`) to
+make sure the fix didn't break anything else. Both must pass before the branch
+is mergeable. Master auto-deploys from Heroku, so a red suite must never reach
+it.
+
+### 4. Commit fix and test together
+
+The test and the fix belong in the same logical change so the protection
+travels with the fix. Keep the commit subject ≤100 chars (per `git-workflow`),
+e.g. `Fix crash on empty synopsis + regression test`.
+
+## What a good regression test asserts
+
+- **The specific failing input.** Reproduce the exact case that broke
+  (the empty field, the null author, the special character, the second click),
+  not a generic happy path.
+- **Behaviour, not implementation.** Assert the observable result (no crash,
+  correct status code, modal closes, right error message), so the test keeps
+  protecting even if the internals are refactored later.
+- **One bug, one focused test.** If a fix addresses several distinct bugs, add
+  a test per bug.
+
+## Frontend bugs (Next.js / React / TypeScript)
+
+Tooling: **Jest + React Testing Library** (`@testing-library/react`,
+`@testing-library/user-event`). Co-locate the test next to the component:
+`BookCard.tsx` → `BookCard.test.tsx`.
+
+Test through user-visible behaviour, not internal state:
+
+- **Render / crash bugs** (e.g. card crashes when `coverUrl` is undefined):
+  render with the offending props and assert it renders without throwing and
+  shows the fallback.
+- **Interaction bugs** (e.g. "Ver más" toggle, modal won't close, double
+  submit): drive it with `userEvent` and assert the resulting DOM
+  (`screen.queryByRole(...)` is gone, button disabled, etc.).
+- **Conditional-UI bugs** (e.g. logged-out user sees the logged-in CTA): render
+  each relevant prop combination and assert the right element appears.
+
+Query by role/label/text the user would perceive
+(`getByRole('button', { name: /pedir ejemplar/i })`), not by test-ids unless
+nothing else works. Assert Spanish copy exactly as the user sees it.
+
+## Backend bugs (Node / Express / Mongoose)
+
+Tooling: **Jest + supertest** for routes; plain Jest for controllers/services
+and model logic. Mirror the source path under the test folder the project
+already uses.
+
+- **Route / API bugs** (wrong status, wrong payload, missing auth check): hit
+  the endpoint with supertest using the input that triggered the bug and assert
+  status + response body. For an auth bug, assert the unauthenticated request is
+  rejected (e.g. `401`), which is exactly the regression you want locked down.
+- **Validation / sanitisation bugs** (e.g. Mongo operator injection like
+  `{ $gt: '' }` slipping into a string field): send the malicious/edge input and
+  assert it's rejected or coerced safely.
+- **Business-rule bugs** (e.g. a book with 0 available copies still showing in
+  search; a copy not being decremented on contact): assert the rule directly on
+  the controller/service result.
+
+**Database safety still rules everything** (per the `senior-backend` agent):
+never write a test that runs destructive operations against real or production
+data. Use an in-memory Mongo (`mongodb-memory-server`) or a disposable test DB,
+seed only what the test needs, and confirm `MONGODB_URI` is not production
+before running. A regression test must never become a way to lose data.
+
+For Stripe-related bugs, reproduce against Stripe **test mode** / mocked Stripe
+only — never live keys.
+
+## When a test is genuinely hard
+
+Some bugs are awkward to test (a third-party outage path, a Heroku-only
+environment quirk, a visual-only glitch). The rule is not "skip the test" — it
+is "don't pretend it's covered". In that order, prefer to:
+
+1. **Narrow the target.** Usually the *logic* underneath the hard-to-test
+   surface can be extracted and unit-tested even if the outer integration can't.
+   Test that.
+2. **Mock the boundary.** Stub the external service (Stripe, SMTP, Mailchimp)
+   and test your code's handling of its success/failure responses.
+3. **If truly untestable**, say so explicitly in the PR/summary: what the bug
+   was, why an automated regression test isn't feasible, and how you verified
+   the fix manually. This is the rare exception, surfaced for the human to
+   accept — not a silent omission.
+
+## Definition of done for a bug fix
+
+- [ ] A test reproduces the bug and **failed** on the unfixed code.
+- [ ] The fix is applied (minimal, focused).
+- [ ] That test now **passes**.
+- [ ] The **full suite** passes (`npm test`).
+- [ ] Fix + test committed together, subject ≤100 chars.
+- [ ] Any untestable exception is explicitly flagged, not hidden.

--- a/.claude/skills/version-bump-frontend:/SKILL.md
+++ b/.claude/skills/version-bump-frontend:/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: version-bump-frontend
+description: >
+  Mantiene actualizado el número de versión del frontend en package.json
+  siguiendo versionado semántico (MAJOR.MINOR.PATCH). Úsala SIEMPRE que vayas a
+  crear una pull request en el repositorio del frontend, antes de abrirla: el
+  número de versión debe subir en el mismo commit/PR según el tipo de cambio.
+  Aplica también si el usuario pide "subir la versión", "bump", "preparar una
+  release" o menciona la versión del package.json del frontend. Infiere el tipo
+  de incremento a partir del cambio y propónlo; si hay duda razonable, pregunta
+  antes de decidir.
+---
+
+# Version bump — Frontend
+
+Sube el número de versión en `package.json` del frontend al preparar una pull
+request, siguiendo versionado semántico: `MAJOR.MINOR.PATCH`.
+
+## Cuándo se aplica
+
+Cada vez que vayas a crear una PR en el repo del frontend. El bump va incluido
+en la misma PR (no en una aparte), idealmente como último commit antes de abrirla.
+
+## Reglas de incremento
+
+Dado `MAJOR.MINOR.PATCH` (p. ej. `9.3.1`):
+
+- **PATCH** (tercer dígito): fix menor. Correcciones de bugs, ajustes de copy,
+  erratas, retoques de estilo puntuales, cambios que no añaden funcionalidad ni
+  alteran la apariencia general. Ej.: `9.3.1 → 9.3.2`.
+- **MINOR** (segundo dígito): nueva feature. Una página nueva, un componente
+  nuevo, un filtro nuevo, una capacidad que antes no existía, sin rediseño
+  global. Al subir MINOR, el PATCH vuelve a `0`. Ej.: `9.3.2 → 9.4.0`.
+- **MAJOR** (primer dígito): cambio grande. En el frontend, esto incluye:
+  - **Cambio de diseño significativo**: rediseño de una página completa con el
+    nuevo sistema de diseño, cambio de identidad visual, migración del look &
+    feel de una sección entera.
+  - **Actualización de librerías importantes** (no menores): subir de major a
+    React, Next.js, Material UI, TypeScript; migración de Pages Router a App
+    Router; cambios estructurales del stack.
+
+  Al subir MAJOR, MINOR y PATCH vuelven a `0`. Ej.: `9.4.0 → 10.0.0`.
+
+> Una actualización de librería **menor** (patch/minor de una dependencia,
+> bumps de seguridad rutinarios) NO es MAJOR: trátala como PATCH salvo que
+> introduzca una feature visible (entonces MINOR).
+
+## Cómo decidir (híbrido: inferir + confirmar si dudas)
+
+1. Mira el conjunto de cambios de la PR (diff, archivos tocados, descripción).
+2. Clasifícalo en PATCH / MINOR / MAJOR según las reglas de arriba.
+3. **Si el tipo es claro**, propón el nuevo número y aplícalo, dejándolo dicho
+   en el resumen: "Subo de `9.3.1` a `9.4.0` (MINOR: nueva página de detalle)".
+4. **Si hay duda razonable** (p. ej. un rediseño parcial que no sabes si cuenta
+   como "significativo", o varios cambios de distinto nivel mezclados),
+   **pregunta antes de decidir**, ofreciendo la opción que crees correcta y la
+   alternativa. Cuando se mezclan varios cambios, manda el de mayor nivel.
+
+## Cómo aplicar el bump
+
+1. Lee la versión actual en `package.json` (campo `version`).
+2. Calcula la nueva según la regla, reseteando a `0` los dígitos inferiores.
+3. Edita **solo** el campo `version` de `package.json`. No toques otros campos
+   ni reordenes el archivo.
+4. Si el proyecto tiene `package-lock.json`, actualiza también ahí el campo
+   `version` de nivel raíz para que coincida (no regeneres todo el lockfile).
+5. Haz un commit dedicado y descriptivo, p. ej.:
+   `chore(release): bump version to 9.4.0`.
+
+## Lo que NO haces
+
+- No subes la versión sin saber el tipo de cambio: si dudas, pregunta.
+- No tratas un bump de seguridad rutinario de una dependencia como MAJOR.
+- No editas el changelog ni etiquetas releases salvo que te lo pidan.
+- No tocas la versión directamente en `master`: el bump va en la rama de la PR
+  (Heroku auto-despliega desde `master`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ Hay un plan de migración y rediseño por fases en `/docs/plan-mejora.md`.
 Resumen: modernizar Next.js (9 → 15) y rediseñar A LA VEZ, página por página,
 manteniendo la web viva. NO hacer un rewrite de golpe.
 
+## Workflow de PRs
+- Al crear una pull request, aplica la skill `version-bump-frontend`:
+  sube la versión en `package.json` (semver) según el tipo de cambio
+  antes de abrir la PR.
+- El bump va en la rama de la PR, nunca directo en master.
+
 ### Estado actual
 - [x] Fase A0: corregir erratas de la home ("encotrar", "liteararios")
 - [x] Fase A1: definir sistema de diseño

--- a/docs/footer-spec.md
+++ b/docs/footer-spec.md
@@ -1,0 +1,298 @@
+# Footer — Especificación de diseño v1
+
+Sección footer de Reseñan Sancho. Sustituye el footer actual manteniendo
+los mismos contenidos (links legales, redes sociales, URLs) pero adaptando
+el diseño al nuevo sistema visual.
+
+---
+
+## Stack y restricciones
+
+- Next.js 9.3.1 · React 16 · TypeScript
+- Material UI + styled-components
+- Fuentes: Fraunces (weight 600) + Source Sans 3 (weight 400 y 600)
+- **No Tailwind**. Estilos en styled-components o `sx` prop de MUI.
+
+---
+
+## Tokens del sistema de diseño
+
+```ts
+colors: {
+  tinta:       '#3D3A35',  // fondo del footer
+  marron:      '#6B4A16',  // logo en la franja inferior
+  mustaza:     '#F2B705',  // hover de links y redes
+  crema:       '#FBF1D8',
+  bordeClaro:  '#d4c9b0',
+}
+```
+
+---
+
+## Estructura general
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  FONDO: tinta #3D3A35                                      │
+│  padding: 36px 28px 20px                                   │
+│                                                            │
+│  ┌─────────────────────────────┐  ┌─────────────────────┐ │
+│  │  AVISOS LEGALES             │  │         SÍGUENOS    │ │
+│  │                             │  │                     │ │
+│  │  ¿Qué es Reseñan Sancho?…  │  │  Instagram      [i] │ │
+│  │  Aviso legal y Política…   │  │  Twitter / X    [i] │ │
+│  │                             │  │  Facebook       [i] │ │
+│  │                             │  │  Email          [i] │ │
+│  └─────────────────────────────┘  └─────────────────────┘ │
+│  ─────────────────────────────────────────────────────     │
+│  Reseñan Sancho                                  v1.0.0   │
+└────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Layout
+
+```css
+display: grid;
+grid-template-rows: 1fr auto;  /* cuerpo + franja inferior */
+```
+
+### Cuerpo (`.footer-body`)
+
+```css
+display: grid;
+grid-template-columns: 1fr auto;
+gap: 32px;
+align-items: start;
+padding-bottom: 24px;
+border-bottom: 0.5px solid rgba(212, 201, 176, 0.25);
+margin-bottom: 16px;
+```
+
+---
+
+## Columna izquierda — Avisos legales
+
+### Etiqueta de sección
+- Texto: `"AVISOS LEGALES"`
+- Source Sans 3, 10px, weight 600, uppercase, letter-spacing 0.1em
+- Color: `#a89880`
+- Margin-bottom: 12px
+
+### Links legales
+
+Extraer URLs y textos del footer actual del proyecto. Los dos links son:
+
+```
+Texto: "¿Qué es Reseñan Sancho? Preguntas frecuentes."
+href:  /about
+
+Texto: "Aviso legal y Política de Privacidad."
+href:  /legal
+```
+
+Estilos de cada `<a>`:
+```
+font-family: Source Sans 3, 13px, weight 400
+color: #d4c9b0
+text-decoration: none
+line-height: 1.45
+display: block
+
+Hover: color: #F2B705
+```
+
+Contenedor de links: `display: flex; flex-direction: column; gap: 8px`
+
+---
+
+## Columna derecha — Redes sociales
+
+### Etiqueta de sección
+- Texto: `"SÍGUENOS"`
+- Mismo estilo que la etiqueta de la columna izquierda
+- `text-align: right`
+- Margin-bottom: 12px
+
+### Links de redes
+
+Extraer URLs del footer actual del proyecto. Redes presentes:
+Instagram, Twitter / X, Facebook, Email (mailto).
+
+Cada link es un `<a>` con:
+```
+display: flex
+align-items: center
+gap: 8px
+font-size: 12px
+color: #a89880
+text-decoration: none
+justify-content: flex-end   ← alineado a la derecha
+
+Hover: color: #F2B705
+Hover > .social-icon: border-color: #F2B705
+```
+
+Etiqueta de texto visible (accesibilidad): "Instagram", "Twitter / X",
+"Facebook", "Email" — siempre visible junto al icono, no solo en
+`aria-label`.
+
+#### Icono (`.social-icon`)
+
+```
+width: 28px · height: 28px
+border-radius: 6px
+border: 0.5px solid rgba(212, 201, 176, 0.3)
+display: flex · align-items: center · justify-content: center
+flex-shrink: 0
+```
+
+Iconos SVG inline (14×14px, stroke o fill `#a89880`):
+- **Instagram**: rect redondeado + círculo interior + punto superior derecho
+- **Twitter / X**: glifo X (path oficial de la marca)
+- **Facebook**: glifo f
+- **Email**: sobre (rect + path en V)
+
+> Todos los `<a>` de redes deben tener `aria-label` descriptivo:
+> `"Reseñan Sancho en Instagram"`, `"Reseñan Sancho en Twitter"`, etc.
+> El `target="_blank"` lleva `rel="noopener noreferrer"`.
+
+---
+
+## Franja inferior
+
+Separada del cuerpo por el borde superior del cuerpo (ver layout).
+
+```css
+display: flex;
+justify-content: space-between;
+align-items: center;
+```
+
+### Logo (izquierda)
+- Texto: `"Reseñan Sancho"`
+- Fraunces 600, 14px, color marrón `#6B4A16`
+
+### Versión (derecha)
+
+Mostrar la versión del frontend extraída de `package.json` en build time.
+
+```ts
+// En el componente Footer:
+import packageJson from '../../package.json';
+const version = packageJson.version;
+```
+
+> En Next.js 9 con TypeScript, añadir en `tsconfig.json`:
+> `"resolveJsonModule": true`
+> para permitir el import de JSON.
+> Si ya está activado, no tocar.
+
+Estilos del texto de versión:
+```
+font-family: Source Sans 3
+font-size: 11px
+color: rgba(168, 152, 128, 0.6)   ← muy discreto, mismo tono que el fondo
+font-variant-numeric: tabular-nums
+```
+
+Formato del texto: `v{version}` — ejemplo: `v1.0.0`
+
+---
+
+## Accesibilidad
+
+- El footer usa `<footer>` como elemento raíz (semántica correcta)
+- Los links legales son `<a>` reales con `href`, nunca `<span>`
+- Los links de redes tienen `aria-label` descriptivo y `rel="noopener noreferrer"`
+- El texto de versión va en `<span aria-hidden="true">` — es información
+  para el desarrollador, no relevante para lectores de pantalla
+- Contraste verificado:
+  - `#d4c9b0` sobre `#3D3A35`: ratio ~5.6:1 ✓ WCAG AA
+  - `#a89880` sobre `#3D3A35`: ratio ~3.2:1 (texto decorativo / pequeño,
+    aceptable para etiquetas de 10px en uppercase)
+  - `#F2B705` sobre `#3D3A35` en hover: ratio ~8.1:1 ✓
+
+---
+
+## Responsive (mobile-first)
+
+**< 480px:**
+
+El grid de dos columnas pasa a una columna:
+```css
+grid-template-columns: 1fr;
+gap: 24px;
+```
+
+La columna de redes sociales:
+```
+align-items: flex-start   ← en móvil, alineadas a la izquierda
+```
+
+La etiqueta "SÍGUENOS":
+```
+text-align: left
+```
+
+Los links de redes en móvil:
+```
+justify-content: flex-start
+```
+
+Padding del footer en móvil: `28px 20px 16px`
+
+---
+
+## Componente sugerido
+
+```
+Footer/
+  index.tsx        ← componente completo
+```
+
+### Props
+
+El componente no necesita props: los links y URLs se leen del footer
+actual (datos estáticos), y la versión se importa de `package.json`
+en tiempo de build.
+
+```ts
+// Sin props — componente autónomo
+const Footer: React.FC = () => { ... }
+export default Footer;
+```
+
+---
+
+## Notas de implementación
+
+- **URLs y datos de redes**: copiar exactamente los href del footer
+  actual del proyecto. No inventar ni hardcodear nuevos.
+- **`resolveJsonModule`**: verificar que está en `true` en `tsconfig.json`
+  antes de importar `package.json`. Si no está, añadirlo; es un cambio
+  seguro y sin efectos secundarios en Next.js 9.
+- **No eliminar el footer actual** hasta que el nuevo esté en producción
+  y verificado. Trabajar en rama `feature/footer-redesign`.
+
+---
+
+## Coherencia con otras páginas
+
+| Elemento            | Home (hero/stats) | Footer          |
+|---------------------|-------------------|-----------------|
+| Fondo               | Crema / Blanco    | Tinta `#3D3A35` |
+| Tipografía títulos  | Fraunces 600      | Fraunces 600    |
+| Tipografía cuerpo   | Source Sans 3     | Source Sans 3   |
+| Color hover links   | Teja `#C75B22`    | Mustaza `#F2B705` (sobre oscuro) |
+| Borde separador     | 0.5px `#d4c9b0`  | 0.5px `rgba(212,201,176,0.25)` |
+
+> El hover usa mustaza en lugar de teja porque sobre el fondo oscuro
+> la teja pierde contraste (~2.8:1), mientras que la mustaza alcanza
+> ~8.1:1. Mismo sistema de diseño, aplicado con criterio de contraste.
+
+---
+
+*Para implementar este diseño, delegar en el agente `senior-frontend` con
+este documento, `home-hero-spec.md` y `navbar-spec.md` como contexto.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "engines": {
     "node": "20.x"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,61 +1,230 @@
 import React from 'react';
 import styledComponents from 'styled-components';
-import { Typography, Link } from '@mui/material';
-import InstagramIcon from '@mui/icons-material/Instagram';
-import TwitterIcon from '@mui/icons-material/Twitter';
-import FacebookIcon from '@mui/icons-material/Facebook';
-import MailIcon from '@mui/icons-material/Mail';
+import packageJson from '../../package.json';
 
-const Footer = () => (
+const version = packageJson.version;
+
+const InstagramSvg = (): JSX.Element => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#a89880" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+    <circle cx="12" cy="12" r="4" />
+    <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+  </svg>
+);
+
+const TwitterSvg = (): JSX.Element => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="#a89880" aria-hidden="true">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z" />
+  </svg>
+);
+
+const FacebookSvg = (): JSX.Element => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="#a89880" aria-hidden="true">
+    <path d="M15.12 5.32H17V2.14A26.11 26.11 0 0 0 14.26 2c-2.72 0-4.58 1.66-4.58 4.7v2.6H6.61v3.56h3.07V22h3.68v-9.14h3.06l.46-3.56h-3.52V7.05c0-1.03.28-1.73 1.76-1.73Z" />
+  </svg>
+);
+
+const EmailSvg = (): JSX.Element => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#a89880" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect x="2" y="4" width="20" height="16" rx="2" />
+    <path d="m2 7 10 6 10-6" />
+  </svg>
+);
+
+const Footer = (): JSX.Element => (
   <StyledFooter>
-    <StyledLegal>
-      <Typography variant="h6">Avisos Legales</Typography>
-      <Link href="/about">
-        <Typography component="p" color="secondary">¿Qué es Reseñan Sancho? Preguntas frecuentes.</Typography>
-      </Link>
-      <Link href="/legal">
-        <Typography component="p" color="secondary">Aviso legal y Política de Privacidad.</Typography>
-      </Link>
-    </StyledLegal>
-    <StyledSocial>
-      <Link href="https://www.instagram.com/resenansancho/">
-        <InstagramIcon />
-      </Link>
-      <Link href="https://twitter.com/ResenanSancho">
-        <TwitterIcon />
-      </Link>
-      <Link href="https://www.facebook.com/resenansancho/">
-        <FacebookIcon />
-      </Link>
-      <Link href="mailto:alejandro@resenansancho.com">
-        <MailIcon />
-      </Link>
-    </StyledSocial>
+    <FooterBody className="footer-body">
+      <LegalColumn>
+        <SectionLabel>AVISOS LEGALES</SectionLabel>
+        <LegalLinks>
+          <LegalLink href="/about">¿Qué es Reseñan Sancho? Preguntas frecuentes.</LegalLink>
+          <LegalLink href="/legal">Aviso legal y Política de Privacidad.</LegalLink>
+        </LegalLinks>
+      </LegalColumn>
+
+      <SocialColumn>
+        <SectionLabel className="social-label">SÍGUENOS</SectionLabel>
+        <SocialLinks>
+          <SocialLink
+            href="https://www.instagram.com/resenansancho/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Reseñan Sancho en Instagram"
+          >
+            <span>Instagram</span>
+            <SocialIcon className="social-icon"><InstagramSvg /></SocialIcon>
+          </SocialLink>
+          <SocialLink
+            href="https://twitter.com/ResenanSancho"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Reseñan Sancho en Twitter"
+          >
+            <span>Twitter / X</span>
+            <SocialIcon className="social-icon"><TwitterSvg /></SocialIcon>
+          </SocialLink>
+          <SocialLink
+            href="https://www.facebook.com/resenansancho/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Reseñan Sancho en Facebook"
+          >
+            <span>Facebook</span>
+            <SocialIcon className="social-icon"><FacebookSvg /></SocialIcon>
+          </SocialLink>
+          <SocialLink
+            href="mailto:alejandro@resenansancho.com"
+            aria-label="Escribir un email a Reseñan Sancho"
+          >
+            <span>Email</span>
+            <SocialIcon className="social-icon"><EmailSvg /></SocialIcon>
+          </SocialLink>
+        </SocialLinks>
+      </SocialColumn>
+    </FooterBody>
+
+    <BottomBar>
+      <Logo>Reseñan Sancho</Logo>
+      <Version aria-hidden="true">{`v${version}`}</Version>
+    </BottomBar>
   </StyledFooter>
 );
 
-const StyledLegal = styledComponents.footer`
-  float: left;
-`;
-
-const StyledSocial = styledComponents.footer`
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-gap: 1rem;
-  margin-right: 5%;
-  float: right;
-`;
-
 const StyledFooter = styledComponents.footer`
-  margin-top: 3rem;
-  margin-bottom: 0;
-  padding: 2%;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  background: ${({ theme }) => theme.ink};
+  padding: 36px 28px 20px;
   margin-left: calc(50% - 50vw);
   width: 100vw;
-  height: 8rem;
-  color: #f6f6f6;
-  background-color: #080807;
-  text-align: left;
+
+  @media (max-width: 480px) {
+    padding: 28px 20px 16px;
+  }
+`;
+
+const FooterBody = styledComponents.div`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 32px;
+  align-items: start;
+  padding-bottom: 24px;
+  border-bottom: 0.5px solid rgba(212, 201, 176, 0.25);
+  margin-bottom: 16px;
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+`;
+
+const SectionLabel = styledComponents.p`
+  margin: 0 0 12px;
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #a89880;
+`;
+
+const LegalColumn = styledComponents.div``;
+
+const LegalLinks = styledComponents.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const LegalLink = styledComponents.a`
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 13px;
+  font-weight: 400;
+  color: ${({ theme }) => theme.lightBorder};
+  text-decoration: none;
+  line-height: 1.45;
+  display: block;
+
+  &:hover {
+    color: ${({ theme }) => theme.amber};
+  }
+`;
+
+const SocialColumn = styledComponents.div`
+  .social-label {
+    text-align: right;
+  }
+
+  @media (max-width: 480px) {
+    .social-label {
+      text-align: left;
+    }
+  }
+`;
+
+const SocialLinks = styledComponents.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+
+  @media (max-width: 480px) {
+    align-items: flex-start;
+  }
+`;
+
+const SocialLink = styledComponents.a`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 12px;
+  color: #a89880;
+  text-decoration: none;
+  justify-content: flex-end;
+
+  &:hover {
+    color: ${({ theme }) => theme.amber};
+  }
+
+  &:hover .social-icon {
+    border-color: ${({ theme }) => theme.amber};
+  }
+
+  @media (max-width: 480px) {
+    justify-content: flex-start;
+  }
+`;
+
+const SocialIcon = styledComponents.span`
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 0.5px solid rgba(212, 201, 176, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const BottomBar = styledComponents.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Logo = styledComponents.span`
+  font-family: 'Fraunces', serif;
+  font-weight: 600;
+  font-size: 14px;
+  color: ${({ theme }) => theme.brown};
+`;
+
+const Version = styledComponents.span`
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 11px;
+  color: rgba(168, 152, 128, 0.6);
+  font-variant-numeric: tabular-nums;
 `;
 
 export default Footer;


### PR DESCRIPTION
## Qué

Rediseña el footer de la home aplicando el nuevo sistema de diseño, siguiendo `docs/footer-spec.md`. Mantiene los mismos contenidos (links legales y URLs de redes) que el footer anterior, adaptados al look & feel sobre fondo oscuro (tinta `#3D3A35`).

## Cambios

- **`src/components/Footer.tsx`** reescrito:
  - Layout `<footer>` en grid: cuerpo de dos columnas (Avisos legales / Síguenos) + franja inferior (logo + versión).
  - Usa tokens del tema (`ink`, `brown`, `amber`, `lightBorder`).
  - Links legales como `<a>` reales (`/about`, `/legal`).
  - Redes: Instagram, Twitter / X, Facebook, Email — con etiqueta de texto visible, icono SVG inline (28px box), `aria-label` y `rel="noopener noreferrer"`. URLs copiadas tal cual del footer anterior.
  - Versión `v{version}` importada de `package.json` (`aria-hidden`).
  - Responsive mobile-first (<480px → una columna, redes alineadas a la izquierda).
  - Hover en mustaza `#F2B705` (contraste sobre fondo oscuro).
- **Version bump** MINOR: `1.0.0 → 1.1.0` (nueva feature/componente).
- Añade `docs/footer-spec.md`.

## Verificación

- `tsc --noEmit`: sin errores nuevos del Footer (los de `BookListItem`/`index.tsx` son preexistentes).
- `next build`: compila correctamente.
- Pendiente de revisión visual con `npm run dev` antes de merge a `master` (Heroku auto-despliega).

🤖 Generated with [Claude Code](https://claude.com/claude-code)