### PR TITLE
Account Fase 5: rediseño de Ayuda (acordeón)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,5 +90,7 @@ Notas:
 - [x] Fase A6: rediseñar la sección de libros
 - [x] Fase A7: rediseñar la sección de reseñadores literarios
 - [x] Fase A8: rediseñar la sección de detalle de un libro.
+- [x] Fase A9: rediseñar el área personal (perfil, espacios literarios, mis
+  libros, añade libro y ayuda) como página única `/account`.
 
 - (actualiza esta lista según avances)

--- a/src/views/AccountPage/sections/HelpSection.tsx
+++ b/src/views/AccountPage/sections/HelpSection.tsx
@@ -1,56 +1,133 @@
-import React from 'react';
-import styledComponents from 'styled-components';
-import { useTranslation } from 'react-i18next';
-import {
-  Card,
-  CardContent,
-  Typography,
-} from '@mui/material';
+import React, { useId, useState } from 'react';
+import styled from 'styled-components';
 import SectionHeader from '../SectionHeader';
 
-const HelpSection: React.FC = (): JSX.Element => {
-  const { t } = useTranslation();
+const SUPPORT_EMAIL = 'alejandro@resenansancho.com';
+
+const Chevron: React.FC = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="18" height="18" aria-hidden="true">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+interface AccordionItemProps {
+  question: string;
+  children: React.ReactNode;
+}
+
+const AccordionItem: React.FC<AccordionItemProps> = ({ question, children }) => {
+  const [open, setOpen] = useState(false);
+  const baseId = useId();
+  const headerId = `${baseId}-header`;
+  const bodyId = `${baseId}-body`;
+
   return (
-    <>
-      <SectionHeader title={t('titles.help')} />
-      <Card>
-        <CardContent>
-          <StyledContainer>
-            <Typography variant="h5">Mi libro no aparece en el listado de libros disponibles</Typography>
-            <Typography variant="body1">
-              Para que un libro aparezca en el listado lo primero que debes hacer es darlo
-              de alta con la opción del menú AÑADE LIBRO. Luego, en la opción MIS LIBROS,
-              puedes administrar tus ejemplares. Para que un libro aparezca en el listado debe
-              tener ejemplares disponibles. Para agregar ejemplares disponibles de tu libro,
-              puedes hacerlo con la opción PROMOCIONAR.
-            </Typography>
-          </StyledContainer>
-          <StyledContainer>
-            <Typography variant="h5">Mi perfil de reseñador aparece muy atrás en los resultados</Typography>
-            <Typography variant="body1">
-              ¡No te preocupes, hay solución! Si te has registrado hace un tiempo como reseñador
-              literario es posible que aparezcas atrás en los resultados de búsqueda. Si quieres
-              aparecer en los primeros lugares, escríbenos a alejandro@resenansancho.com y te
-              subimos.
-            </Typography>
-          </StyledContainer>
-          <StyledContainer>
-            <Typography variant="h5">
-              ¿Tienes una duda, algún comentario o algo no funciona cómo esperabas?
-            </Typography>
-            <Typography variant="body1">
-              No dudes en escribir a alejandro@resenansancho.com
-            </Typography>
-          </StyledContainer>
-        </CardContent>
-      </Card>
-    </>
+    <Item>
+      <Header
+        id={headerId}
+        type="button"
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <Question>{question}</Question>
+        <ChevronHolder $open={open}><Chevron /></ChevronHolder>
+      </Header>
+      {open && (
+        <Body id={bodyId} role="region" aria-labelledby={headerId}>
+          {children}
+        </Body>
+      )}
+    </Item>
   );
 };
 
-const StyledContainer = styledComponents.div`
-  margin-bottom: 5%;
-  width: 90%;
+const HelpSection: React.FC = (): JSX.Element => (
+  <>
+    <SectionHeader title="Ayuda" subtitle="Respuestas a las preguntas más habituales." />
+
+    <AccordionItem question="Mi libro no aparece en el listado de libros disponibles">
+      Para que un libro aparezca en el listado, primero debes darlo de alta en
+      «Añade libro». Luego, en «Mis libros», puedes administrar tus ejemplares: un
+      libro solo aparece en el listado cuando tiene ejemplares disponibles. Para
+      añadirlos, usa la opción «Promocionar».
+    </AccordionItem>
+
+    <AccordionItem question="Mi perfil de reseñador aparece muy atrás en los resultados">
+      ¡No te preocupes, hay solución! Si te registraste hace tiempo como reseñador,
+      es posible que aparezcas atrás en los resultados. Si quieres aparecer en los
+      primeros lugares, escríbenos a <EmailLink href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</EmailLink>
+      {' '}y te subimos.
+    </AccordionItem>
+
+    <AccordionItem question="¿Tienes una duda, un comentario o algo no funciona como esperabas?">
+      No dudes en escribirnos a <EmailLink href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</EmailLink>.
+    </AccordionItem>
+  </>
+);
+
+const Item = styled.div`
+  border: 1px solid ${({ theme }) => theme.lightBorder};
+  border-radius: 10px;
+  margin-bottom: 10px;
+  background: ${({ theme }) => theme.white};
+`;
+
+const Header = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  min-height: 48px;
+  padding: 14px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.terracotta};
+    outline-offset: -2px;
+    border-radius: 10px;
+  }
+`;
+
+const Question = styled.span`
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.ink};
+`;
+
+const ChevronHolder = styled.span<{ $open: boolean }>`
+  display: inline-flex;
+  flex-shrink: 0;
+  color: ${({ theme }) => theme.brown};
+  transition: transform 0.2s ease;
+  transform: rotate(${({ $open }) => ($open ? '180deg' : '0deg')});
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+
+const Body = styled.div`
+  padding: 0 16px 16px;
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 14px;
+  line-height: 1.7;
+  color: #5a524a;
+`;
+
+const EmailLink = styled.a`
+  color: ${({ theme }) => theme.terracotta};
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 export default HelpSection;


### PR DESCRIPTION
## Contexto

Fase 5 (última) del rediseño del área personal (ver `docs/account-spec.md`,
Sección 7). Rediseña **Ayuda** como acordeón accesible. Va contra la rama
intermedia `feature/my-private-area-redesign`.

**Solo UI**: contenido estático, sin datos de backend.

## Cambios

- **`HelpSection`** reescrita como **acordeón** de 3 preguntas (se pueden abrir
  varias a la vez).
- Accesibilidad: cada cabecera es un `<button>` con `aria-expanded` y
  `aria-controls`; el cuerpo es `role="region"` con `aria-labelledby`; chevron
  decorativo (`aria-hidden`) que **rota respetando `prefers-reduced-motion``;
  foco visible en la cabecera. Ids únicos con `useId`.
- Emails renderizados como enlaces `mailto:` reales.
- Marca **Fase A9** como completada en `CLAUDE.md`.

## Verificación

- `tsc --noEmit`: sin errores nuevos (los de `BookListItem`/`index.tsx` son
  preexistentes).
- `next build`: compila; `/account` se genera (14.1 kB).
- Pendiente revisión visual con `npm run dev`: abrir/cerrar preguntas (teclado y
  ratón) y enlaces de email.

> Sin bump de versión (queda en 1.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)