### PR TITLE
Disable book request button when zero copies available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "engines": {
     "node": "20.x"

--- a/src/views/BookDetailPage/BookDetailCTA.tsx
+++ b/src/views/BookDetailPage/BookDetailCTA.tsx
@@ -84,9 +84,12 @@ const AvailabilityRow = styled.div`
   gap: 6px;
 `;
 
-const GreenDot = styled.span`
+// Dot color reflects availability: success (green) when in stock, muted (grey)
+// when unavailable. We avoid the previous always-green "GreenDot" so the empty
+// state isn't visually misleading.
+const AvailabilityDot = styled.span<{ $available: boolean }>`
   font-size: 10px;
-  color: ${({ theme }) => theme.success};
+  color: ${({ theme, $available }) => ($available ? theme.success : theme.muted)};
   line-height: 1;
 `;
 
@@ -122,6 +125,21 @@ const RequestButton = styled.button`
     transform: scale(0.98);
   }
 
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    background: ${({ theme }) => theme.amber};
+  }
+
+  /* No hover/active feedback while disabled */
+  &:disabled:hover {
+    background: ${({ theme }) => theme.amber};
+  }
+
+  &:disabled:active {
+    transform: none;
+  }
+
   ${reducedMotion}
 `;
 
@@ -133,16 +151,27 @@ const BookDetailCTA: React.FC<BookDetailCTAProps> = ({
   onRequest,
 }) => {
   const router = useRouter();
+  const isAvailable = copies > 0;
   return (
     <Section aria-label="Pedir ejemplar">
       {isLoggedIn ? (
         <>
           <AvailabilityRow>
-            <GreenDot aria-hidden="true">●</GreenDot>
-            <AvailabilityText>{copies} ejemplares disponibles</AvailabilityText>
+            <AvailabilityDot $available={isAvailable} aria-hidden="true">
+              ●
+            </AvailabilityDot>
+            <AvailabilityText>
+              {isAvailable
+                ? `${copies} ${copies === 1 ? 'ejemplar disponible' : 'ejemplares disponibles'}`
+                : 'No disponible por ahora'}
+            </AvailabilityText>
           </AvailabilityRow>
 
-          <RequestButton onClick={onRequest}>
+          <RequestButton
+            onClick={onRequest}
+            disabled={!isAvailable}
+            aria-label={isAvailable ? undefined : 'No disponible por ahora'}
+          >
             Pedir un ejemplar →
           </RequestButton>
         </>


### PR DESCRIPTION
## Problem
A logged-in user viewing a book with **0 copies available** could still click "Pedir un ejemplar", open the contact modal, and send a request for an unavailable book.

## Fix
In `src/views/BookDetailPage/BookDetailCTA.tsx`:
- `RequestButton` is now `disabled` when `copies <= 0` (native `disabled`, so it blocks both click and keyboard activation and is announced by assistive tech), with disabled styling (dimmed, `not-allowed` cursor, no hover/active feedback).
- Availability dot switches from green (`theme.success`) to grey (`theme.muted`) when out of stock, and the text shows "No disponible por ahora" instead of the misleading "0 ejemplares disponibles".
- Singular/plural copy fix: "1 ejemplar disponible" vs "N ejemplares disponibles".
- `aria-label` conveys the unavailable reason on the disabled button (the dot is `aria-hidden`).

Implemented via `senior-frontend`, reviewed by `frontend-reviewer` (transient `$available` prop for styled-components v6, copy, and a11y findings all applied — no blockers remaining).

## Version
PATCH bump `1.4.0 → 1.4.1` (bug fix).

## Regression test
The repo has no working Jest/RTL harness yet (no config/transformer/jest-dom/setup), so the fail-first regression test will land in a **separate branch/PR** that bootstraps the test infrastructure.

## Manual verification checklist
- [ ] Book with 0 copies: button disabled, grey dot, "No disponible por ahora"
- [ ] Book with 1 copy: "1 ejemplar disponible", button enabled
- [ ] Book with N copies: "N ejemplares disponibles", button enabled, modal opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)