### PR TITLE
Add Jest + RTL test harness and BookDetailCTA regression test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,16 @@
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
     "import/extensions": "off",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": [
+          "**/*.test.{ts,tsx,js,jsx}",
+          "**/jest.setup.ts",
+          "**/jest.config.js"
+        ]
+      }
+    ],
     "react/jsx-filename-extension": [
       1,
       {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,19 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  // Points to the Next.js app root so next/jest can load next.config.js and .env files
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  // Only run co-located tests under src/. The legacy tests/ directory predates the
+  // Next 9 -> 15 / styled-components migration and depends on removed packages
+  // (@material-ui/core, react-test-renderer); it does not run and is excluded here.
+  roots: ['<rootDir>/src'],
+};
+
+// next/jest wraps the custom config and applies SWC transform + CSS/image mocks
+module.exports = createJestConfig(customConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "ISC",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,10 @@
         "styled-components": "^6.1.13"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest": "^29.5.14",
         "@types/node": "^20.16.11",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -56,6 +59,13 @@
       "engines": {
         "node": "20.x"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2696,6 +2706,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -2722,6 +2759,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -2834,6 +2885,52 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -3656,7 +3753,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4468,6 +4564,13 @@
         "is-in-browser": "^1.0.2"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -4701,7 +4804,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6684,6 +6786,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -8669,6 +8781,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -9621,6 +9743,20 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10424,6 +10560,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
     "styled-components": "^6.1.13"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20.16.11",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "",
   "engines": {
     "node": "20.x"

--- a/src/views/BookDetailPage/BookDetailCTA.test.tsx
+++ b/src/views/BookDetailPage/BookDetailCTA.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for BookDetailCTA.
+ *
+ * Bug fixed: when isLoggedIn=true and copies<=0, the "Pedir un ejemplar" button
+ * was enabled, allowing onRequest to fire with no copies available. The fix
+ * added disabled={!isAvailable} to the RequestButton.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+
+import { StyledTheme } from '../../store/context/StylesContext/Theme';
+import BookDetailCTA from './BookDetailCTA';
+
+// next/router is used inside the unauth branch; mock it so tests that render
+// the logged-in branch don't blow up on missing router context.
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    asPath: '/books/test-book',
+    pathname: '/books/test-book',
+    query: {},
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderCTA(props: { isLoggedIn: boolean; copies: number; onRequest: () => void }) {
+  const { isLoggedIn, copies, onRequest } = props;
+  return render(
+    <ThemeProvider theme={StyledTheme}>
+      <BookDetailCTA isLoggedIn={isLoggedIn} copies={copies} onRequest={onRequest} />
+    </ThemeProvider>,
+  );
+}
+
+// ─── Logged-in branch ────────────────────────────────────────────────────────
+
+describe('BookDetailCTA — logged-in user', () => {
+  describe('when copies === 0 (out of stock)', () => {
+    it('renders the "Pedir un ejemplar" button as disabled', () => {
+      // REGRESSION: before the fix, disabled={!isAvailable} was absent,
+      // so the button was always enabled when isLoggedIn=true.
+      // When disabled, the button's aria-label is "No disponible por ahora"
+      // (set by the component), which becomes its accessible name.
+      const onRequest = jest.fn();
+      renderCTA({ isLoggedIn: true, copies: 0, onRequest });
+
+      const button = screen.getByRole('button', { name: /no disponible por ahora/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('does not call onRequest when the disabled button is clicked', async () => {
+      // REGRESSION: clicking the enabled button used to fire onRequest even with
+      // zero copies, triggering a request for an unavailable book.
+      const user = userEvent.setup();
+      const onRequest = jest.fn();
+      renderCTA({ isLoggedIn: true, copies: 0, onRequest });
+
+      const button = screen.getByRole('button', { name: /no disponible por ahora/i });
+      // userEvent respects the disabled attribute and will not fire the click handler
+      await user.click(button);
+
+      expect(onRequest).not.toHaveBeenCalled();
+    });
+
+    it('shows "No disponible por ahora" availability text', () => {
+      renderCTA({ isLoggedIn: true, copies: 0, onRequest: jest.fn() });
+      expect(screen.getByText('No disponible por ahora')).toBeInTheDocument();
+    });
+  });
+
+  describe('when copies > 0 (in stock)', () => {
+    it('renders the "Pedir un ejemplar" button as enabled', () => {
+      renderCTA({ isLoggedIn: true, copies: 3, onRequest: jest.fn() });
+
+      const button = screen.getByRole('button', { name: /pedir un ejemplar/i });
+      expect(button).toBeEnabled();
+    });
+
+    it('calls onRequest when the button is clicked', async () => {
+      const user = userEvent.setup();
+      const onRequest = jest.fn();
+      renderCTA({ isLoggedIn: true, copies: 3, onRequest });
+
+      await user.click(screen.getByRole('button', { name: /pedir un ejemplar/i }));
+
+      expect(onRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows plural availability text for multiple copies', () => {
+      renderCTA({ isLoggedIn: true, copies: 3, onRequest: jest.fn() });
+      expect(screen.getByText('3 ejemplares disponibles')).toBeInTheDocument();
+    });
+
+    it('shows singular availability text for exactly 1 copy', () => {
+      renderCTA({ isLoggedIn: true, copies: 1, onRequest: jest.fn() });
+      expect(screen.getByText('1 ejemplar disponible')).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── Unauthenticated branch ──────────────────────────────────────────────────
+
+describe('BookDetailCTA — unauthenticated user', () => {
+  it('shows the "Crear cuenta gratis" link instead of the request button', () => {
+    renderCTA({ isLoggedIn: false, copies: 5, onRequest: jest.fn() });
+
+    expect(
+      screen.getByRole('link', { name: /crear cuenta gratis/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /pedir un ejemplar/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the "Inicia sesión" link', () => {
+    renderCTA({ isLoggedIn: false, copies: 5, onRequest: jest.fn() });
+    expect(screen.getByRole('link', { name: /inicia sesión/i })).toBeInTheDocument();
+  });
+
+  it('shows the unauthenticated prompt text', () => {
+    renderCTA({ isLoggedIn: false, copies: 5, onRequest: jest.fn() });
+    expect(
+      screen.getByText('Para pedir un ejemplar necesitas una cuenta gratuita.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "preserveConstEnums": true,
     "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "src/**/*", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "src/**/*", ".next/types/**/*.ts", "jest.setup.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Stacked on #65 (base is `bugfix/book-cta-disable-zero-copies`). Will retarget to `master` once #65 merges.

## What this adds
Bootstraps the frontend test harness (there was none working before — `jest`/`@testing-library/react` were listed but no config, transformer, `jest-dom`, or setup), and adds a fail-first regression test for the zero-copies request-button bug fixed in #65.

### Harness
- `jest.config.js` — `next/jest` (SWC transform, CSS/alias handling), `testEnvironment: jsdom`, `setupFilesAfterEnv` → `jest.setup.ts`.
- `jest.setup.ts` — imports `@testing-library/jest-dom`.
- `roots: ['<rootDir>/src']` — Jest only runs co-located `src/` tests. The legacy `tests/` dir predates the Next 9→15 / styled-components migration and imports removed packages (`@material-ui/core`, `react-test-renderer`); it does not run and is excluded (documented in the config).
- Dev deps: `@testing-library/jest-dom`, `@testing-library/user-event`, `@types/jest`.
- `tsconfig.json`: include `jest.setup.ts` so jest-dom matcher types resolve in tests.
- `.eslintrc.json`: allow test files / jest config to import devDependencies.

### Regression test — `src/views/BookDetailPage/BookDetailCTA.test.tsx` (10 tests)
Asserts user-visible behaviour via role/text queries (no test-ids):
- `copies === 0`: button disabled, clicking does **not** call `onRequest`, shows "No disponible por ahora".
- `copies > 0`: button enabled, click calls `onRequest`, shows "N ejemplares disponibles".
- `copies === 1`: shows "1 ejemplar disponible".
- Unauthenticated branch: shows the register/login links, no request button.

**Fail-first verified:** reverting `disabled={!isAvailable}` makes exactly the 2 guard assertions fail for the right reason; restoring the fix → 10/10 green.

Implemented by `rtl-test-author`, reviewed by `frontend-reviewer` (approved, no blockers; recommendations on `@types/jest` and the eslint allowance applied here).

## Version
PATCH bump `1.4.1 → 1.4.2`.

## Follow-ups (not in this PR)
- Legacy `tests/` suites are dead (removed deps) — delete or port in a separate cleanup.
- Production bug spotted by the test author: the unauth branch nests a styled `<a>` (`PrimaryButtonAnchor`) inside Next 15 `<Link>`, producing invalid `<a>`-in-`<a>` HTML — worth its own bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)