### PR TITLE
Fix invalid nested <a> from legacy Link+passHref pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "ISC",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "",
   "engines": {
     "node": "20.x"

--- a/src/views/AccountPage/components/BooksEmptyState.test.tsx
+++ b/src/views/AccountPage/components/BooksEmptyState.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for BooksEmptyState.
+ *
+ * Bug fixed: the "Añadir mi primer libro" CTA used the legacy Next 9 pattern
+ * `<Link passHref><styled.a /></Link>`, which caused Link to render its own
+ * wrapping <a> around the child <a> — invalid HTML in Next 15.
+ * Fix: PrimaryButton is now `styled(Link)` rendered directly, producing a
+ * single <a> element with no nesting.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+import { StyledTheme } from '../../../store/context/StylesContext/Theme';
+import BooksEmptyState from './BooksEmptyState';
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+function renderEmptyState() {
+  return render(
+    <ThemeProvider theme={StyledTheme}>
+      <BooksEmptyState />
+    </ThemeProvider>,
+  );
+}
+
+// ─── Content ─────────────────────────────────────────────────────────────────
+
+describe('BooksEmptyState — content', () => {
+  it('renders the empty-state headline', () => {
+    renderEmptyState();
+    expect(screen.getByText('Aún no has publicado ningún libro')).toBeInTheDocument();
+  });
+
+  it('renders the supporting text', () => {
+    renderEmptyState();
+    expect(
+      screen.getByText('Publica tu primer libro para empezar a buscar reseñas.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the CTA link with correct label', () => {
+    renderEmptyState();
+    expect(
+      screen.getByRole('link', { name: /añadir mi primer libro/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── Nested-anchor regression (invalid-HTML bug) ─────────────────────────────
+// Bug: `<Link passHref><styled.a href="...">` produced <a><a> — invalid HTML.
+// Fix: `styled(Link)` renders directly as a single <a> element.
+
+describe('BooksEmptyState — nested-anchor regression', () => {
+  it('does not nest an <a> inside another <a>', () => {
+    // REGRESSION: before the fix, PrimaryButton was styled.a wrapped in
+    // <Link passHref>, producing an <a> nested inside the Link's own <a>.
+    const { container } = renderEmptyState();
+
+    expect(container.querySelectorAll('a a')).toHaveLength(0);
+  });
+
+  it('renders the CTA as a single <a> element', () => {
+    // REGRESSION: styled(Link) must produce exactly one anchor tag for the CTA.
+    const { container } = renderEmptyState();
+
+    const allAnchors = container.querySelectorAll('a');
+    expect(allAnchors).toHaveLength(1);
+    expect(allAnchors[0].tagName).toBe('A');
+  });
+
+  it('CTA anchor has href pointing to the add-book section', () => {
+    // REGRESSION: the single anchor must carry the correct navigation target.
+    renderEmptyState();
+
+    const ctaLink = screen.getByRole('link', { name: /añadir mi primer libro/i });
+    expect(ctaLink).toHaveAttribute('href', '/account?section=addBook');
+  });
+});

--- a/src/views/AccountPage/components/BooksEmptyState.tsx
+++ b/src/views/AccountPage/components/BooksEmptyState.tsx
@@ -16,9 +16,9 @@ const BooksEmptyState: React.FC = (): JSX.Element => (
     </IconHolder>
     <Title>Aún no has publicado ningún libro</Title>
     <Text>Publica tu primer libro para empezar a buscar reseñas.</Text>
-    <Link href="/account?section=addBook" passHref>
-      <PrimaryButton>+ Añadir mi primer libro</PrimaryButton>
-    </Link>
+    <PrimaryButton href="/account?section=addBook">
+      + Añadir mi primer libro
+    </PrimaryButton>
   </Wrapper>
 );
 
@@ -51,7 +51,7 @@ const Text = styled.p`
   margin: 0 0 20px;
 `;
 
-const PrimaryButton = styled.a`
+const PrimaryButton = styled(Link)`
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/src/views/BookDetailPage/BookDetailCTA.test.tsx
+++ b/src/views/BookDetailPage/BookDetailCTA.test.tsx
@@ -127,3 +127,38 @@ describe('BookDetailCTA — unauthenticated user', () => {
     ).toBeInTheDocument();
   });
 });
+
+// ─── Nested-anchor regression (invalid-HTML bug) ─────────────────────────────
+// Bug: the old Next 9 pattern `<Link passHref><styled.a /></Link>` caused Link
+// to render its own <a> wrapping the child <a>, producing invalid HTML in Next 15.
+// Fix: PrimaryButtonAnchor and LoginLink are now `styled(Link)` rendered directly
+// (no wrapper Link, no passHref), so each produces exactly one <a>.
+
+describe('BookDetailCTA — nested-anchor regression', () => {
+  it('does not nest an <a> inside another <a> in the unauthenticated branch', () => {
+    // REGRESSION: before the fix, <Link passHref><PrimaryButtonAnchor> produced
+    // <a href="/register"><a ...>Crear cuenta gratis</a></a> — invalid HTML.
+    const { container } = renderCTA({ isLoggedIn: false, copies: 5, onRequest: jest.fn() });
+
+    expect(container.querySelectorAll('a a')).toHaveLength(0);
+  });
+
+  it('renders the register link as a standalone <a> with href="/register"', () => {
+    // REGRESSION: styled(Link) must produce a single navigable anchor, not a nested one.
+    renderCTA({ isLoggedIn: false, copies: 5, onRequest: jest.fn() });
+
+    const registerLink = screen.getByRole('link', { name: /crear cuenta gratis/i });
+    expect(registerLink.tagName).toBe('A');
+    expect(registerLink).toHaveAttribute('href', '/register');
+  });
+
+  it('renders the login link as a standalone <a> with an href containing "/login"', () => {
+    // REGRESSION: styled(Link) for LoginLink must resolve to a single <a>
+    // whose href encodes the current path as a "previous" query param.
+    renderCTA({ isLoggedIn: false, copies: 5, onRequest: jest.fn() });
+
+    const loginLink = screen.getByRole('link', { name: /inicia sesión/i });
+    expect(loginLink.tagName).toBe('A');
+    expect(loginLink.getAttribute('href')).toMatch(/^\/login/);
+  });
+});

--- a/src/views/BookDetailPage/BookDetailCTA.tsx
+++ b/src/views/BookDetailPage/BookDetailCTA.tsx
@@ -47,8 +47,9 @@ const UnauthRow = styled.div`
   flex-wrap: wrap;
 `;
 
-// Used as an anchor so next/link can pass the href down
-const PrimaryButtonAnchor = styled.a`
+// styled(Link) renders a single semantic <a> with these styles, avoiding the
+// legacy <Link><a/></Link> nesting that produced invalid HTML in Next 13+.
+const PrimaryButtonAnchor = styled(Link)`
   background: ${({ theme }) => theme.terracotta};
   color: ${({ theme }) => theme.white};
   font-family: 'Source Sans 3', sans-serif;
@@ -70,7 +71,7 @@ const PrimaryButtonAnchor = styled.a`
   }
 `;
 
-const LoginLink = styled.a`
+const LoginLink = styled(Link)`
   font-family: 'Source Sans 3', sans-serif;
   font-size: 13px;
   color: ${({ theme }) => theme.terracotta};
@@ -182,14 +183,13 @@ const BookDetailCTA: React.FC<BookDetailCTAProps> = ({
           </UnauthText>
 
           <UnauthRow>
-            {/* Next.js 9 requires a child <a> inside Link */}
-            <Link href="/register" passHref>
-              <PrimaryButtonAnchor>Crear cuenta gratis →</PrimaryButtonAnchor>
-            </Link>
+            <PrimaryButtonAnchor href="/register">
+              Crear cuenta gratis →
+            </PrimaryButtonAnchor>
 
-            <Link href={{ pathname: '/login', query: { previous: router.asPath } }} passHref>
-              <LoginLink>Inicia sesión</LoginLink>
-            </Link>
+            <LoginLink href={{ pathname: '/login', query: { previous: router.asPath } }}>
+              Inicia sesión
+            </LoginLink>
           </UnauthRow>
         </>
       )}

--- a/src/views/BookDetailPage/index.tsx
+++ b/src/views/BookDetailPage/index.tsx
@@ -34,7 +34,7 @@ const BreadcrumbBar = styled.nav`
   }
 `;
 
-const BreadcrumbLink = styled.a`
+const BreadcrumbLink = styled(Link)`
   display: inline-flex;
   align-items: center;
   gap: 5px;
@@ -81,9 +81,7 @@ const BookDetailPage: React.FC<BookDetailPageProps> = ({ book }) => {
     <Wrapper>
       {/* Breadcrumb */}
       <BreadcrumbBar aria-label="Migas de pan">
-        <Link href="/books" passHref>
-          <BreadcrumbLink>← Volver a libros</BreadcrumbLink>
-        </Link>
+        <BreadcrumbLink href="/books">← Volver a libros</BreadcrumbLink>
       </BreadcrumbBar>
 
       <BookDetailHero

--- a/src/views/BooksPage/BookCard.test.tsx
+++ b/src/views/BooksPage/BookCard.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Regression tests for BookCard.
+ *
+ * Bug fixed: the "Pedir ejemplar gratuito" CTA used the legacy Next 9 pattern
+ * `<Link passHref><styled.a />`, which caused Link to wrap its own <a> around
+ * the child <a> — invalid HTML in Next 15.
+ * Fix: CTAButton is now `styled(Link)` rendered directly, producing a single
+ * <a> element pointing to `/books/<id>` with no nesting.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+import { StyledTheme } from '../../store/context/StylesContext/Theme';
+import BookCard from './BookCard';
+import { Book } from '../../interfaces/books';
+
+// react-i18next: return the last segment of the key as a plain string so genre
+// badges render predictably without loading real translation files.
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+  }),
+}));
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+const BOOK_FIXTURE: Book = {
+  _id: 'book-123',
+  title: 'El Quijote',
+  author: { name: 'Miguel', lastName: 'de Cervantes' },
+  synopsis: 'Un hidalgo manchego que enloquece leyendo libros de caballerías.',
+  genre: 'ADV',
+  formats: ['papel', 'epub'],
+  cover: '',
+  editorial: 'Autor independiente',
+  pages: 320,
+  copies: 5,
+  freePromoAvailable: false,
+};
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+function renderCard(book: Book = BOOK_FIXTURE) {
+  return render(
+    <ThemeProvider theme={StyledTheme}>
+      <BookCard book={book} />
+    </ThemeProvider>,
+  );
+}
+
+// ─── Content ─────────────────────────────────────────────────────────────────
+
+describe('BookCard — content', () => {
+  it('renders the book title', () => {
+    renderCard();
+    expect(screen.getByRole('heading', { name: /el quijote/i })).toBeInTheDocument();
+  });
+
+  it('renders the author name', () => {
+    renderCard();
+    expect(screen.getByText(/miguel/i)).toBeInTheDocument();
+    expect(screen.getByText(/de cervantes/i)).toBeInTheDocument();
+  });
+
+  it('renders the synopsis', () => {
+    renderCard();
+    expect(screen.getByText(/hidalgo manchego/i)).toBeInTheDocument();
+  });
+
+  it('renders format chips', () => {
+    renderCard();
+    expect(screen.getByText('papel')).toBeInTheDocument();
+    expect(screen.getByText('epub')).toBeInTheDocument();
+  });
+
+  it('renders the CTA link with its aria-label', () => {
+    renderCard();
+    expect(
+      screen.getByRole('link', { name: 'Pedir ejemplar de El Quijote' }),
+    ).toBeInTheDocument();
+  });
+
+  it('uses the cover image when provided', () => {
+    const book = { ...BOOK_FIXTURE, cover: 'https://example.com/cover.jpg' };
+    renderCard(book);
+    const img = screen.getByAltText('Portada de El Quijote');
+    expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg');
+  });
+});
+
+// ─── Nested-anchor regression (invalid-HTML bug) ─────────────────────────────
+// Bug: CTAButton was styled.a wrapped in <Link passHref>, so Link rendered its
+// own <a> around the child styled.a — producing invalid <a><a> nesting.
+// Fix: CTAButton is styled(Link), which resolves to a single <a>.
+
+describe('BookCard — nested-anchor regression', () => {
+  it('does not nest an <a> inside another <a>', () => {
+    // REGRESSION: before the fix, <Link passHref><CTAButton> produced
+    // <a href="/books/book-123"><a aria-label="...">Pedir...</a></a>.
+    const { container } = renderCard();
+
+    expect(container.querySelectorAll('a a')).toHaveLength(0);
+  });
+
+  it('renders the CTA as a single <a> element', () => {
+    // REGRESSION: styled(Link) must produce exactly one anchor for the CTA.
+    const { container } = renderCard();
+
+    const allAnchors = container.querySelectorAll('a');
+    expect(allAnchors).toHaveLength(1);
+    expect(allAnchors[0].tagName).toBe('A');
+  });
+
+  it('CTA anchor href points to the book detail page', () => {
+    // REGRESSION: the anchor must carry the correct /books/<id> href.
+    renderCard();
+
+    const ctaLink = screen.getByRole('link', { name: 'Pedir ejemplar de El Quijote' });
+    expect(ctaLink).toHaveAttribute('href', '/books/book-123');
+  });
+
+  it('preserves the aria-label "Pedir ejemplar de <title>" on the CTA anchor', () => {
+    // Accessibility: aria-label must survive the styled(Link) conversion.
+    renderCard();
+
+    expect(
+      screen.getByRole('link', { name: 'Pedir ejemplar de El Quijote' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/views/BooksPage/BookCard.tsx
+++ b/src/views/BooksPage/BookCard.tsx
@@ -163,9 +163,9 @@ const MetaDot = styled.span`
   color: ${({ theme }) => theme.lightBorder};
 `;
 
-// CTAButton is an anchor styled to look like a button.
-// We use <a> via next/link so the browser handles prefetching.
-const CTAButton = styled.a`
+// CTAButton is a next/link styled to look like a button. Styling Link directly
+// yields a single <a> (with prefetching) instead of nesting <a> inside <a>.
+const CTAButton = styled(Link)`
   background: ${({ theme }) => theme.amber};
   color: ${({ theme }) => theme.ink};
   font-family: 'Source Sans 3', sans-serif;
@@ -263,12 +263,12 @@ const BookCard: React.FC<BookCardProps> = ({ book }) => {
 
         <Divider />
 
-        {/* passHref forwards the href to the styled <a> child (CTAButton) */}
-        <Link href={`/books/${book._id}`} passHref>
-          <CTAButton aria-label={`Pedir ejemplar de ${book.title}`}>
-            Pedir ejemplar gratuito →
-          </CTAButton>
-        </Link>
+        <CTAButton
+          href={`/books/${book._id}`}
+          aria-label={`Pedir ejemplar de ${book.title}`}
+        >
+          Pedir ejemplar gratuito →
+        </CTAButton>
       </CardBody>
     </Card>
   );


### PR DESCRIPTION
Stacked on #66 (base `test/book-cta-regression-and-harness`, which is itself stacked on #65). Will retarget down the stack as the lower PRs merge. **Merge order: #65 → #66 → this.**

## Problem
The project migrated Next 9 → 15 but kept the old `<Link href=... passHref>` + child styled `<a>` pattern. In Next 13+, `<Link>` renders its own `<a>`, so this produced `<a>` nested inside `<a>` — invalid HTML and a React `validateDOMNesting` warning.

## Fix
Converted each `styled.a` to `styled(Link)` and rendered it directly with `href` (dropping the wrapper `<Link>`/`passHref`), yielding a single semantic `<a>` that keeps all styles, hover/focus/active, prefetching, and aria-labels. This matches an existing repo pattern (`HeroCard.tsx`). 5 spots across 4 files:
- `BookDetailCTA.tsx` — `PrimaryButtonAnchor`, `LoginLink`
- `BookDetailPage/index.tsx` — `BreadcrumbLink`
- `BooksPage/BookCard.tsx` — `CTAButton`
- `AccountPage/components/BooksEmptyState.tsx` — `PrimaryButton`

`grep passHref src/` is now clean.

## Regression tests (fail-first)
Added tests asserting **no `<a>` is nested inside another `<a>`** (`container.querySelectorAll('a a')` is empty) plus single-anchor + correct-href checks, for `BookDetailCTA` (unauth branch), `BooksEmptyState`, and `BookCard` (incl. preserved aria-label). Full suite: **29 tests, 3 suites, green.**

**Fail-first proof:** reverting `BooksEmptyState` to the old pattern made the `a a` assertion fail (found a nested anchor) and React logged `validateDOMNesting: <a> cannot appear as a descendant of <a>`; restoring the fix → green.

Implemented by `senior-frontend`, reviewed by `frontend-reviewer` (approved, no blockers), tests by `rtl-test-author`.

## Version
PATCH bump `1.4.2 → 1.4.3`.

## Follow-up (not in this PR)
`BookDetailPage/index.tsx`'s breadcrumb wasn't unit-tested in isolation because the page pulls in `ModalContact` (MUI, i18next, ga4, fetch). It uses the same `styled(Link)` pattern that's covered elsewhere. Suggest extracting the breadcrumb into its own component for a focused test later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)