### PR TITLE
Corregir stale closure en useForm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "ISC",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "",
   "engines": {
     "node": "20.x"

--- a/src/utils/customHooks/useForm.test.tsx
+++ b/src/utils/customHooks/useForm.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Regression tests for useForm.
+ *
+ * Bug fixed: `setFormValues` spread the `form` captured in its own render's
+ * closure. Two updates landing in the same cycle (two mount effects, or two
+ * calls before a repaint) both spread the SAME stale object, so the second one
+ * silently reverted the first. It surfaced in ProfileSection: the avatar effect
+ * wrote the raw initial state back over the normalised legacy country.
+ *
+ * Fix: the setter takes the functional form of `setState`, so every update
+ * spreads the latest queued state instead of a snapshot.
+ */
+import React, { useEffect } from 'react';
+import {
+  act, render, renderHook, screen,
+} from '@testing-library/react';
+
+import useForm from './useForm';
+
+// Two `setFormValues` routed through separate mount effects: same mechanics as
+// calling the setter twice in a row, but proving it also holds when the calls
+// come from effects that know nothing about each other.
+function TwoFieldEffectsOnMount() {
+  const [form, setFormValues] = useForm({ country: 'Spain', avatar: '' });
+
+  useEffect(() => {
+    setFormValues('country', 'ES');
+  }, []);
+
+  useEffect(() => {
+    setFormValues('avatar', 'avatar.png');
+  }, []);
+
+  return <div>{`${form.country}|${form.avatar}`}</div>;
+}
+
+// The actual ProfileSection shape, and a distinct failure mode from the one
+// above: the first effect REPLACES the form via `loadForm`, the second writes a
+// single field. The stale spread used to throw the replacement away entirely.
+function LoadThenSetEffectsOnMount() {
+  const [form, setFormValues, loadForm] = useForm({ country: 'Spain', avatar: '' });
+
+  useEffect(() => {
+    loadForm({ country: 'NO-COUNTRY', avatar: '' });
+  }, []);
+
+  useEffect(() => {
+    setFormValues('avatar', 'a.png');
+  }, []);
+
+  return <div>{`${form.country}|${form.avatar}`}</div>;
+}
+
+describe('useForm', () => {
+  it('keeps both values when two fields are updated in the same render cycle', () => {
+    const { result } = renderHook(() => useForm({ name: '', lastName: '' }));
+    const [, setFormValues] = result.current;
+
+    act(() => {
+      setFormValues('name', 'Alonso');
+      setFormValues('lastName', 'Quijano');
+    });
+
+    expect(result.current[0]).toEqual({ name: 'Alonso', lastName: 'Quijano' });
+  });
+
+  it('keeps both values when two mount effects update different fields', () => {
+    render(<TwoFieldEffectsOnMount />);
+
+    expect(screen.getByText('ES|avatar.png')).toBeInTheDocument();
+  });
+
+  it('keeps the loaded form when a mount effect writes a field after loadForm', () => {
+    render(<LoadThenSetEffectsOnMount />);
+
+    expect(screen.getByText('NO-COUNTRY|a.png')).toBeInTheDocument();
+  });
+
+  it('applies the last write when the same field is updated twice in the same render cycle', () => {
+    // `toggleInArray` (SpacesSection) and `toggleFormat` (AddBookSection) lean
+    // on last-write-wins for a single field within one cycle.
+    const { result } = renderHook(() => useForm({ country: 'ES' }));
+
+    act(() => {
+      result.current[1]('country', 'MX');
+      result.current[1]('country', 'AR');
+    });
+
+    expect(result.current[0]).toEqual({ country: 'AR' });
+  });
+
+  it('replaces the whole form when loadForm runs after setFormValues in the same cycle', () => {
+    // `loadForm` is a plain `set`, not a merge, and must stay that way: it is
+    // how AddBookSection resets the form (`{ ...initForm, ...state }`). Turning
+    // it functional "for consistency" would silently start merging, so fields
+    // written earlier in the cycle would survive a reset.
+    const { result } = renderHook(() => useForm({ title: '', cover: '' }));
+
+    act(() => {
+      result.current[1]('cover', 'cover.png');
+      result.current[2]({ title: 'Quijote' });
+    });
+
+    expect(result.current[0]).toEqual({ title: 'Quijote' });
+  });
+
+  it('applies sequential updates made in separate render cycles', () => {
+    const { result } = renderHook(() => useForm({ name: '', lastName: '' }));
+
+    act(() => {
+      result.current[1]('name', 'Alonso');
+    });
+    act(() => {
+      result.current[1]('lastName', 'Quijano');
+    });
+
+    expect(result.current[0]).toEqual({ name: 'Alonso', lastName: 'Quijano' });
+  });
+
+  it('overwrites a field that already has a value', () => {
+    const { result } = renderHook(() => useForm({ country: 'Spain' }));
+
+    act(() => {
+      result.current[1]('country', 'ES');
+    });
+
+    expect(result.current[0]).toEqual({ country: 'ES' });
+  });
+
+  it('replaces the whole form when loadForm is called', () => {
+    const { result } = renderHook(() => useForm({ name: 'Alonso', country: 'ES' }));
+
+    act(() => {
+      result.current[1]('name', 'Sancho');
+    });
+
+    act(() => {
+      result.current[2]({ email: 'sancho@example.com' });
+    });
+
+    // A replacement, not a merge: fields missing from the new object are gone.
+    expect(result.current[0]).toEqual({ email: 'sancho@example.com' });
+  });
+});

--- a/src/utils/customHooks/useForm.tsx
+++ b/src/utils/customHooks/useForm.tsx
@@ -2,10 +2,17 @@ import { useState } from 'react';
 
 const useForm = (props: any): [any, Function, Function] => {
   const [form, setForm] = useState(props);
+  // Functional update on purpose: spreading the `form` of the current render
+  // would make two updates in the same cycle (e.g. two mount effects) both
+  // spread the same stale snapshot, so the second one would revert the first.
   const setFormValues = (
     name: string,
     value: string,
-  ): void => setForm({ ...form, [name]: value });
+  ): void => setForm((prev: any) => ({ ...prev, [name]: value }));
+  // Plain `set`, not functional, and deliberately asymmetric with the setter
+  // above: this is a full replacement used to load or reset a form, so when it
+  // runs last in a cycle it must win outright. Merging into the previous state
+  // would stop resets from clearing fields.
   const loadForm = (formFields: object) => {
     setForm(formFields);
   };

--- a/src/views/AccountPage/sections/ProfileSection.tsx
+++ b/src/views/AccountPage/sections/ProfileSection.tsx
@@ -35,10 +35,10 @@ const withNormalisedCountry = (user: UserLogged): UserLogged => ({
 const ProfileSection: React.FC = (): JSX.Element => {
   const { t } = useTranslation();
   const { user, setUserLogged } = useContext(UserContext);
-  // Normalised here as well as on load: `useForm`'s setter closes over the form
-  // of its render, so the avatar effect below would write the raw initial state
-  // (legacy country included) back on top of the normalised one.
-  const [updateForm, setUpdateForm, loadForm] = useForm(withNormalisedCountry(user));
+  // Normalisation lives in the load effect below, which also runs on mount:
+  // it is the only path that survives a user change. Until it flushes, the raw
+  // legacy country is harmless — `CountrySelect` falls back to the placeholder.
+  const [updateForm, setUpdateForm, loadForm] = useForm(user);
   const [avatarURL, uploadAvatar] = useUploadImages(updateForm.avatar);
   const [response, setResponse] = useState<Response>({ success: undefined, message: undefined });
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
Arregla la raíz del bug que en la PR #74 se parcheó localmente en `ProfileSection`.

## El bug

`src/utils/customHooks/useForm.tsx` hacía:

```ts
setForm({ ...form, [name]: value })
```

`form` viene capturado del closure del render. Dos escrituras en el mismo ciclo — dos `useEffect` en el mismo montaje, por ejemplo — se pisan: la segunda escribe sobre el estado del render 1 y **revierte silenciosamente la primera**.

Se manifestó en el perfil: el efecto del avatar revertía la normalización del país legacy, y el usuario acababa enviando `country: "Spain"` a una API que valida `/^[A-Z]{2}$/`, con lo que fallaba el guardado entero y perdía también el resto de la edición.

## El arreglo

Actualización funcional, una línea. **Firma, `loadForm` y tipo de retorno intactos**, así que ninguno de los 8 consumidores necesita cambios.

`loadForm` se deja deliberadamente **no funcional**: es un reemplazo completo y debe ganar cuando corre el último del ciclo. `AddBookSection` depende de ello para que su reset (`{ ...initForm, ...state }`) limpie campos. Hay un test que fija esa semántica, precisamente para que nadie lo "uniformice" por coherencia y lo convierta en un merge silencioso.

## Tests (fail-first)

Se escribieron **antes** del arreglo. 3 de los 8 fallan contra el hook roto, incluida la forma real de producción:

```
● keeps the loaded form when a mount effect writes a field after loadForm
    Unable to find an element with the text: NO-COUNTRY|a.png
    <div>Spain|a.png</div>
```

Los otros 5 son guardas de contrato: pasan antes y después, y protegen el comportamiento que no debe cambiar.

Suite completa: **16 suites / 119 tests en verde**.

## Simplificación de `ProfileSection`

Con el hook arreglado, la doble aplicación de `withNormalisedCountry` que metió la PR #74 sobra. Se deja solo en el efecto de carga, que es la única ruta que sobrevive a un cambio de usuario.

> ⚠️ **`ProfileSection.tsx` y `useForm.tsx` viajan acoplados.** Con el hook viejo y el `ProfileSection` nuevo, `ProfileSection.test.tsx` falla con `Received value: "Spain"`. Un revert parcial o un cherry-pick que se lleve uno sin el otro reintroduce el bug original en producción.

## Análisis de riesgo

El cambio hace las escrituras estrictamente aditivas dentro de un ciclo, así que la pregunta es si algún consumidor dependía sin querer del revertido. Auditados los 8 uno a uno: `login`, `forgot`, `reset`, `register` y `ModalContact` no tienen escrituras coincidentes en el mismo ciclo; `SpacesSection` tampoco. El único otro caso con colisión real es `AddBookSection`, y ahí el resultado es idéntico antes y después porque `loadForm` corre el último y sigue siendo un `set` plano.

Matiz que no cambia esta PR pero conviene tener presente: `toggleInArray` (`SpacesSection`) y `toggleFormat` (`AddBookSection`) construyen el **valor** a partir del snapshot del render. Este arreglo elimina la obsolescencia del nivel superior, no la del valor. Hoy es inocuo porque salen de eventos discretos, pero no hay que leer este fix como que esos sitios ya son seguros si alguien los agrupa en el futuro.

## Verificación manual pendiente antes de mergear

El hook toca 8 consumidores y `master` autodespliega:

- **Registro de usuario** y **login** — flujo crítico.
- **Modal de contacto** — flujo crítico; que el email llegue con todos los campos.
- **Perfil**: usuario con país legacy, editar otro campo, guardar; luego cambiar avatar y guardar.
- **Espacios literarios** y **añade libro** (incluida subida de portada + carga en modo edición, que es justo el par `setFormValues` + `loadForm`).
- **Recuperar contraseña** (`forgot` / `reset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
