### PR TITLE
SEO S4: /books SSR con facetas indexables (género/formato) + sitemap dinámico (v1.7.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "",
   "engines": {
     "node": "20.x"

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -15,6 +15,11 @@ interface SeoProps {
   // the canonical and og:url.
   path: string;
   noindex?: boolean;
+  // When noindex is set, `follow` keeps crawlers following outbound links
+  // ("noindex,follow") instead of the default "noindex,nofollow". Used by the
+  // listing facets that should not be indexed but must still pass link equity.
+  // Ignored when the page is indexable.
+  follow?: boolean;
   ogImage?: string;
 }
 
@@ -31,6 +36,7 @@ const Seo = ({
   description,
   path,
   noindex = false,
+  follow = false,
   ogImage = DEFAULT_OG_IMAGE,
 }: SeoProps): JSX.Element => {
   const { locale, defaultLocale } = useRouter();
@@ -46,6 +52,10 @@ const Seo = ({
   // Decision: the English locale is kept out of the index for now (no hreflang
   // strategy yet), so any /en page is forced to noindex regardless of the prop.
   const shouldNoindex = noindex || locale === 'en';
+  // The /en forced-noindex path keeps the original "nofollow" (no follow
+  // opt-in there); only an explicit `follow` from an indexable-locale caller
+  // upgrades the directive to "noindex,follow".
+  const robotsContent = follow && locale !== 'en' ? 'noindex,follow' : 'noindex,nofollow';
   const ogLocale = locale === 'en' ? 'en_US' : 'es_ES';
 
   return (
@@ -53,7 +63,7 @@ const Seo = ({
       <title>{title}</title>
       <meta name="description" content={description} />
       <link rel="canonical" href={canonical} />
-      {shouldNoindex && <meta name="robots" content="noindex,nofollow" />}
+      {shouldNoindex && <meta name="robots" content={robotsContent} />}
 
       {/* Open Graph */}
       <meta property="og:title" content={title} />

--- a/src/pages/books.tsx
+++ b/src/pages/books.tsx
@@ -3,33 +3,128 @@ import { GetServerSideProps } from 'next';
 import BooksPage from '../views/BooksPage';
 import { PublicZoneLayout } from '../components/Layouts';
 import { Seo } from '../components';
+import { getBooks, GetBooksResult } from '../utils/seo/getBooks';
+import { isValidGenreSlug, isValidFormatSlug } from '../utils/seo/facets';
+import {
+  ListFacets,
+  computeListIndexing,
+  buildListTitle,
+  buildListDescription,
+  buildListPath,
+} from '../utils/seo/listSeo';
 
-const Books: React.FC = (): JSX.Element => (
-  <>
-    <Seo
-      title="Libros para reseñar | Reseñan Sancho"
-      description="Encuentra libros gratis para reseñar en tu blog, booktube o bookstagram. Filtra por género y formato y elige tu próxima lectura en Reseñan Sancho."
-      path="/books"
-    />
-    <PublicZoneLayout>
-      <BooksPage />
-    </PublicZoneLayout>
-  </>
-);
+interface BooksRouteProps {
+  facets: ListFacets;
+  initialData: GetBooksResult;
+}
 
-export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+/** Reads a possibly-array query value as a single string (Next repeats keys). */
+const firstValue = (value: string | string[] | undefined): string | undefined =>
+  (Array.isArray(value) ? value[0] : value);
+
+const Books: React.FC<BooksRouteProps> = ({ facets, initialData }): JSX.Element => {
+  const { indexable } = computeListIndexing(facets, initialData.totalElements);
+
+  // A fetch failure must never emit a cacheable `noindex` (it would drop an
+  // indexable listing out of the index). On failure we keep the page's normal
+  // robots policy and pair it with the 503/no-store set in getServerSideProps.
+  const isFailure = !initialData.ok;
+  const robotsNoindex = !isFailure && !indexable;
+
+  return (
+    <>
+      <Seo
+        title={buildListTitle(facets)}
+        description={buildListDescription(facets)}
+        // Self-canonical: the canonical always points at this same normalized
+        // URL (incl. any page param) so paginated/faceted variants don't fold
+        // into the bare /books.
+        path={buildListPath(facets)}
+        noindex={robotsNoindex}
+        follow={robotsNoindex}
+      />
+      <PublicZoneLayout>
+        <BooksPage initialFacets={facets} initialData={initialData} />
+      </PublicZoneLayout>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<BooksRouteProps> = async ({
+  query,
+  res,
+}) => {
   // Permanently redirect the legacy /books?book=<id> detail URL to the
   // dedicated server-rendered /books/<id> route (phase S3).
   if (query.book) {
     return {
       redirect: {
-        destination: `/books/${query.book}`,
+        destination: `/books/${firstValue(query.book)}`,
         permanent: true,
       },
     };
   }
 
-  return { props: {} };
+  const genreSlug = firstValue(query.genre);
+  const formatSlug = firstValue(query.format);
+  const rawPage = firstValue(query.page);
+
+  // Unknown facet slug → 404. We never serve a listing for a slug that isn't in
+  // the approved map: it would be a thin, uncrawlable dead-end.
+  if (genreSlug && !isValidGenreSlug(genreSlug)) return { notFound: true };
+  if (formatSlug && !isValidFormatSlug(formatSlug)) return { notFound: true };
+
+  const genre = genreSlug ?? null;
+  const format = formatSlug ?? null;
+
+  // Normalize page: only a positive integer > 1 survives in the URL. Any other
+  // present `page` value (1, 0, negatives, non-numeric) 301-redirects to the
+  // clean path so a single URL owns the first page and the canonical stays
+  // consistent with the address bar.
+  const parsedPage = rawPage ? Number.parseInt(rawPage, 10) : 1;
+  const page = Number.isInteger(parsedPage) && parsedPage > 1 ? parsedPage : 1;
+
+  if (rawPage !== undefined && page === 1) {
+    const cleanPath = buildListPath({ genre, format, page: 1 });
+    return {
+      redirect: {
+        destination: cleanPath,
+        permanent: true,
+      },
+    };
+  }
+
+  const initialData = await getBooks({
+    genre: genre ?? undefined,
+    format: format ?? undefined,
+    page,
+  });
+
+  if (!initialData.ok) {
+    // The API blipped (network/HTTP/parse error). Serve 503 so crawlers retry
+    // later and, critically, DON'T cache this broken response — otherwise a
+    // transient failure could get an indexable listing cached as noindex. The
+    // page still renders its normal shell/empty UI with the 503.
+    res.statusCode = 503;
+    res.setHeader('Cache-Control', 'no-store');
+    return {
+      props: {
+        facets: { genre, format, page },
+        initialData,
+      },
+    };
+  }
+
+  // Short-lived caching: the listing changes as books are added, but crawlers
+  // and repeat visitors within a minute can safely share a rendered response.
+  res.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300');
+
+  return {
+    props: {
+      facets: { genre, format, page },
+      initialData,
+    },
+  };
 };
 
 export default Books;

--- a/src/pages/books/[id].tsx
+++ b/src/pages/books/[id].tsx
@@ -12,17 +12,11 @@ import {
   buildBookJsonLd,
   buildBreadcrumbJsonLd,
 } from '../../utils/seo/bookSeo';
+import { serializeJsonLd } from '../../utils/seo/jsonLd';
 
 interface BookDetailRouteProps {
   book: Book;
 }
-
-// JSON.stringify escapes quotes and newlines but not the literal "</script>"
-// sequence, so user-provided fields (e.g. a synopsis) could close the inline
-// script tag early. Escaping every "<" as its unicode form neutralizes the
-// breakout while keeping the JSON valid.
-const serializeJsonLd = (data: unknown): string =>
-  JSON.stringify(data).replace(/</g, '\\u003c');
 
 const BookDetailRoute: React.FC<BookDetailRouteProps> = ({ book }) => {
   const title = buildBookTitle(book);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import Head from 'next/head';
 import { PublicZoneLayout } from '../components/Layouts';
 import HeroSection from '../components/HeroSection';
 import { Seo } from '../components';
+import { serializeJsonLd } from '../utils/seo/jsonLd';
+import { buildWebsiteJsonLd, buildOrganizationJsonLd } from '../utils/seo/homeSeo';
 
 // UserContext queda disponible si en el futuro el hero necesita saber si el
 // usuario está autenticado (p.ej. para cambiar el CTA de "Registrarse").
@@ -14,6 +17,17 @@ const HomePage: React.FC = () => (
       description="El buscador doble para el mundo del libro: escritores encuentran reseñadores y los reseñadores libros gratis para reseñar en su blog, booktube o bookstagram. Filtra por género y formato."
       path="/"
     />
+    <Head>
+      {/* Server-rendered structured data so crawlers get it without JS. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(buildWebsiteJsonLd()) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(buildOrganizationJsonLd()) }}
+      />
+    </Head>
     <PublicZoneLayout showFooter>
       <HeroSection />
     </PublicZoneLayout>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,15 +1,98 @@
 import { GetServerSideProps } from 'next';
 import { SITE_URL } from '../utils/constants/seo';
+import { getBooks } from '../utils/seo/getBooks';
+import { genreCodeToSlug, FORMAT_FACETS } from '../utils/seo/facets';
 
-// Public, indexable static routes only. Private/auth routes are intentionally
+// Public, indexable static routes. Private/auth routes are intentionally
 // excluded (also blocked in robots.txt).
-// TODO: add dynamic book/reviewer URLs once listings are server-rendered (phase S4)
 const STATIC_PATHS = ['/', '/about', '/books', '/reviewers', '/legal'];
 
-const buildSitemap = (): string => {
-  const urls = STATIC_PATHS.map(
-    (path) => `  <url><loc>${SITE_URL}${path === '/' ? '' : path}</loc></url>`,
-  ).join('\n');
+// One wide pull is enough for the current catalogue size (~100s of books). If
+// the API caps the page size below this, we page through totalPages defensively.
+const SITEMAP_PAGE_SIZE = 1000;
+
+// Hard cap on the pagination loop. If the API ignores `size` and paginates with
+// a small page size, totalPages could be large and fire many sequential
+// requests; this bounds the worst case so sitemap generation can't run away.
+const MAX_SITEMAP_PAGES = 50;
+
+interface DynamicUrls {
+  bookIds: string[];
+  genreSlugs: string[];
+  formatValues: string[];
+}
+
+/**
+ * Collects every public book id plus the set of genre/format facets that have
+ * at least one result, in a single pass. Only NON-EMPTY facets are emitted so
+ * the sitemap never advertises a landing URL that would render zero results
+ * (those are noindex anyway).
+ */
+const collectDynamicUrls = async (): Promise<DynamicUrls> => {
+  const first = await getBooks({ page: 1, size: SITEMAP_PAGE_SIZE });
+
+  const books = [...first.books];
+  // Fall back to pagination if the API ignored `size` and returned a partial
+  // first page. totalPages reflects the API's own page size in that case, capped
+  // at MAX_SITEMAP_PAGES so a tiny API page size can't trigger a runaway loop.
+  const lastPage = Math.min(first.totalPages ?? 1, MAX_SITEMAP_PAGES);
+  for (let page = 2; page <= lastPage; page += 1) {
+    // Sequential on purpose: the sitemap is generated rarely and we prefer not
+    // to hammer the API with parallel requests. eslint-disable for await-in-loop.
+    // eslint-disable-next-line no-await-in-loop
+    const next = await getBooks({ page, size: SITEMAP_PAGE_SIZE });
+    books.push(...next.books);
+  }
+
+  const genreCodes = new Set<string>();
+  const formatValues = new Set<string>();
+  const bookIds: string[] = [];
+
+  books.forEach((book) => {
+    if (book._id) bookIds.push(book._id);
+    if (book.genre) genreCodes.add(book.genre);
+    // A book can offer several formats; every present one is a valid facet.
+    (book.formats ?? []).forEach((format) => formatValues.add(format));
+  });
+
+  // Map genre codes → public slugs, dropping any code not in the approved map.
+  const genreSlugs = Array.from(genreCodes)
+    .map((code) => genreCodeToSlug(code))
+    .filter((slug): slug is string => Boolean(slug));
+
+  // Emit known format facets in canonical order, keeping only the ones with at
+  // least one book. Mapping over FORMAT_FACETS already restricts to known values.
+  const orderedFormats = FORMAT_FACETS
+    .map((f) => f.value)
+    .filter((value) => formatValues.has(value));
+
+  return { bookIds, genreSlugs, formatValues: orderedFormats };
+};
+
+// Escape the five XML entities. Today every facet URL has a single param and
+// slugs are [a-z-], so this is defensive: a future second param (introducing a
+// literal `&`) or an unexpected character can't emit invalid XML.
+const escapeXml = (str: string): string =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+const toUrl = (path: string): string => {
+  const loc = escapeXml(`${SITE_URL}${path === '/' ? '' : path}`);
+  return `  <url><loc>${loc}</loc></url>`;
+};
+
+const buildSitemap = (dynamic: DynamicUrls): string => {
+  const staticUrls = STATIC_PATHS.map(toUrl);
+  const bookUrls = dynamic.bookIds.map((id) => toUrl(`/books/${id}`));
+  // Page-1 facet URLs only, no `page` param (matches the canonical listing URL).
+  const genreUrls = dynamic.genreSlugs.map((slug) => toUrl(`/books?genre=${slug}`));
+  const formatUrls = dynamic.formatValues.map((value) => toUrl(`/books?format=${value}`));
+
+  const urls = [...staticUrls, ...bookUrls, ...genreUrls, ...formatUrls].join('\n');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -22,8 +105,21 @@ ${urls}
 const SitemapXml = (): null => null;
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  // Defensive: if the book fetch fails, still emit the static routes rather than
+  // 500 the sitemap. getBooks never throws (it returns ok:false with empty
+  // books), so this catch only guards unexpected throws in the
+  // collection/serialisation. first.books stays [] on failure, so pagination and
+  // the facet collection degrade to just the static routes.
+  let dynamic: DynamicUrls = { bookIds: [], genreSlugs: [], formatValues: [] };
+  try {
+    dynamic = await collectDynamicUrls();
+  } catch {
+    dynamic = { bookIds: [], genreSlugs: [], formatValues: [] };
+  }
+
   res.setHeader('Content-Type', 'text/xml');
-  res.write(buildSitemap());
+  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400');
+  res.write(buildSitemap(dynamic));
   res.end();
 
   return { props: {} };

--- a/src/utils/customHooks/useBooksListFetch.tsx
+++ b/src/utils/customHooks/useBooksListFetch.tsx
@@ -17,8 +17,14 @@ const initialState: State = {
 
 type Filters = QueryParams;
 
-const useBooksListFetch = (): [State, Function, boolean] => {
-  const [state, dispatch] = useReducer(booksListLoad, initialState);
+/**
+ * List fetch state for /books. When `seedState` is provided (SSR-rendered data
+ * from getServerSideProps) the reducer starts already populated, so the first
+ * paint shows real results with no skeleton flash and the view can skip the
+ * redundant mount fetch. Without a seed it behaves exactly as before.
+ */
+const useBooksListFetch = (seedState?: State): [State, Function, boolean] => {
+  const [state, dispatch] = useReducer(booksListLoad, seedState ?? initialState);
   const [loading, setLoading] = useState(false);
   const listRequest = async (filters: Filters = {}): Promise<void> => {
     const options = {

--- a/src/utils/seo/facets.ts
+++ b/src/utils/seo/facets.ts
@@ -1,0 +1,90 @@
+/**
+ * Single source of truth for the public, indexable listing facets.
+ *
+ * The listing URLs (/books?genre=<slug>&format=<value>) are part of the SEO
+ * surface, so the slugs are STABLE public identifiers and must never drift.
+ * They are decoupled from the internal genre `code` the API/DB uses (ADV, ROM…)
+ * and from the i18n keys used elsewhere in the UI: a URL slug is ASCII,
+ * accent-free and human-readable, whereas the code is an opaque DB value.
+ *
+ * Everything a caller needs to translate between the three representations
+ * (slug ↔ code ↔ display label) lives here, plus validation helpers so the
+ * SSR layer can reject unknown facets with a 404 instead of serving garbage.
+ */
+
+export type Locale = 'es' | 'en';
+
+interface GenreFacet {
+  /** Stable public URL slug, e.g. "romantica". */
+  slug: string;
+  /** Internal API/DB genre code, e.g. "ROM". */
+  code: string;
+  /** Display labels for titles/copy. UI text is es-default, en-secondary. */
+  label: { es: string; en: string };
+}
+
+interface FormatFacet {
+  /** The format value is used verbatim as both slug and DB value. */
+  value: string;
+  label: { es: string; en: string };
+}
+
+// Approved slug ↔ code map (see S4 spec). Order is the canonical display order.
+export const GENRE_FACETS: readonly GenreFacet[] = [
+  { slug: 'aventura', code: 'ADV', label: { es: 'aventura', en: 'adventure' } },
+  { slug: 'biografia', code: 'BIO', label: { es: 'biografía', en: 'biography' } },
+  { slug: 'ciencia-ficcion', code: 'CIF', label: { es: 'ciencia ficción', en: 'science fiction' } },
+  { slug: 'crimen', code: 'CRI', label: { es: 'novela negra', en: 'crime' } },
+  { slug: 'erotica', code: 'ERO', label: { es: 'erótica', en: 'erotica' } },
+  { slug: 'fantasia', code: 'FAN', label: { es: 'fantasía', en: 'fantasy' } },
+  { slug: 'infantil', code: 'FCH', label: { es: 'infantil', en: 'children\'s' } },
+  { slug: 'juvenil', code: 'JUV', label: { es: 'juvenil', en: 'young adult' } },
+  { slug: 'novela-historica', code: 'HIF', label: { es: 'novela histórica', en: 'historical fiction' } },
+  { slug: 'humor', code: 'HUM', label: { es: 'humor', en: 'humor' } },
+  { slug: 'poesia', code: 'POE', label: { es: 'poesía', en: 'poetry' } },
+  { slug: 'policiaca', code: 'POL', label: { es: 'policíaca', en: 'crime fiction' } },
+  { slug: 'drama-psicologico', code: 'PSD', label: { es: 'drama psicológico', en: 'psychological drama' } },
+  { slug: 'romantica', code: 'ROM', label: { es: 'romántica', en: 'romance' } },
+  { slug: 'suspense', code: 'SUS', label: { es: 'suspense', en: 'suspense' } },
+  { slug: 'terror', code: 'TER', label: { es: 'terror', en: 'horror' } },
+  { slug: 'thriller', code: 'THR', label: { es: 'thriller', en: 'thriller' } },
+];
+
+// Formats double as their own slug AND their DB value, so there is no mapping to
+// invert — only labels to attach.
+export const FORMAT_FACETS: readonly FormatFacet[] = [
+  { value: 'papel', label: { es: 'papel', en: 'paperback' } },
+  { value: 'epub', label: { es: 'epub', en: 'epub' } },
+  { value: 'mobi', label: { es: 'mobi', en: 'mobi' } },
+  { value: 'pdf', label: { es: 'pdf', en: 'pdf' } },
+  { value: 'audiolibro', label: { es: 'audiolibro', en: 'audiobook' } },
+];
+
+// O(1) lookups built once at module load. The lists are tiny, but the indexes
+// keep the helpers readable and avoid repeated linear scans in the sitemap,
+// which iterates over every book.
+const genreBySlug = new Map(GENRE_FACETS.map((g) => [g.slug, g]));
+const genreByCode = new Map(GENRE_FACETS.map((g) => [g.code, g]));
+const formatByValue = new Map(FORMAT_FACETS.map((f) => [f.value, f]));
+
+// ─── Genre helpers ───────────────────────────────────────────────────────────
+
+export const isValidGenreSlug = (slug: string): boolean => genreBySlug.has(slug);
+
+/** Maps a public slug to the internal API/DB code, or undefined if unknown. */
+export const genreSlugToCode = (slug: string): string | undefined =>
+  genreBySlug.get(slug)?.code;
+
+/** Maps an internal API/DB code back to its public slug, or undefined if unknown. */
+export const genreCodeToSlug = (code: string): string | undefined =>
+  genreByCode.get(code)?.slug;
+
+export const getGenreLabel = (slug: string, locale: Locale = 'es'): string | undefined =>
+  genreBySlug.get(slug)?.label[locale];
+
+// ─── Format helpers ──────────────────────────────────────────────────────────
+
+export const isValidFormatSlug = (slug: string): boolean => formatByValue.has(slug);
+
+export const getFormatLabel = (value: string, locale: Locale = 'es'): string | undefined =>
+  formatByValue.get(value)?.label[locale];

--- a/src/utils/seo/getBooks.ts
+++ b/src/utils/seo/getBooks.ts
@@ -1,0 +1,87 @@
+import { Book } from '../../interfaces/books';
+import { books as BOOKS_URL } from '../../config/routes';
+import { buildQueryString } from '../buildQueryString';
+import { genreSlugToCode } from './facets';
+
+/**
+ * Result shape shared by the listing view, its SSR props and the sitemap.
+ * Mirrors what the `booksListLoad` reducer already stores so SSR data can be
+ * fed straight into the client state without reshaping.
+ */
+export interface GetBooksResult {
+  /**
+   * Whether the fetch actually reached the API and returned a valid response.
+   * `true` for any real response — including a legitimate 0-result facet.
+   * `false` only on a network/HTTP/parse failure. Callers use this to tell a
+   * genuine empty listing (index as noindex,follow) apart from a transient API
+   * blip (serve 503/no-store so a broken response never gets cached).
+   */
+  ok: boolean;
+  books: Book[];
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface GetBooksParams {
+  /** Public genre slug (e.g. "romantica"). Mapped to the DB code internally. */
+  genre?: string;
+  /** Format value, used verbatim (e.g. "papel"). */
+  format?: string;
+  page?: number;
+  /** Optional page size, forwarded to the API when a caller needs a wide pull. */
+  size?: number;
+}
+
+// Failure sentinel: an empty result flagged as a fetch failure (ok: false).
+const FAILED_RESULT: GetBooksResult = {
+  ok: false,
+  books: [],
+  totalElements: 0,
+  totalPages: 0,
+};
+
+/**
+ * Server-side book list fetcher. Reusable by both the /books SSR page and the
+ * sitemap (future genre landing routes will wrap it too). Accepts public SLUGS
+ * and translates the genre slug to the DB code the API expects; the format
+ * value is already the DB value.
+ *
+ * On any network/parse error it resolves to a failure result (`ok: false`)
+ * instead of throwing so the caller (page or sitemap) can decide how to degrade
+ * — neither should 500 because the API blipped. A real response with 0 books
+ * resolves to `ok: true` so callers can distinguish it from a failure.
+ */
+export const getBooks = async ({
+  genre,
+  format,
+  page,
+  size,
+}: GetBooksParams = {}): Promise<GetBooksResult> => {
+  const query = buildQueryString({
+    // Canonical param order: genre, format, page. The API ignores absent keys
+    // (buildQueryString drops empty values), so undefined facets are omitted.
+    genre: genre ? genreSlugToCode(genre) : undefined,
+    format,
+    page,
+    size,
+  });
+
+  try {
+    const response = await fetch(`${BOOKS_URL}?${query}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) return FAILED_RESULT;
+
+    const json = await response.json();
+    return {
+      ok: true,
+      books: Array.isArray(json?.books) ? json.books : [],
+      totalElements: json?.totalElements ?? 0,
+      totalPages: json?.totalPages ?? 0,
+    };
+  } catch {
+    return FAILED_RESULT;
+  }
+};

--- a/src/utils/seo/homeSeo.ts
+++ b/src/utils/seo/homeSeo.ts
@@ -1,0 +1,28 @@
+import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE } from '../constants/seo';
+
+// Absolute logo URL for the Organization schema (relative paths aren't allowed).
+const LOGO_URL = DEFAULT_OG_IMAGE.startsWith('http')
+  ? DEFAULT_OG_IMAGE
+  : `${SITE_URL}${DEFAULT_OG_IMAGE}`;
+
+/**
+ * schema.org/WebSite for the home page. No SearchAction: the site search is a
+ * faceted listing, not a query-string sitelinks search box, so advertising one
+ * would be misleading.
+ */
+export const buildWebsiteJsonLd = (): Record<string, unknown> => ({
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: SITE_NAME,
+  url: `${SITE_URL}/`,
+  inLanguage: 'es-ES',
+});
+
+/** schema.org/Organization for the home page, reusing the brand logo. */
+export const buildOrganizationJsonLd = (): Record<string, unknown> => ({
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: SITE_NAME,
+  url: `${SITE_URL}/`,
+  logo: LOGO_URL,
+});

--- a/src/utils/seo/jsonLd.ts
+++ b/src/utils/seo/jsonLd.ts
@@ -1,0 +1,10 @@
+/**
+ * Serializes JSON-LD for inline injection via dangerouslySetInnerHTML.
+ *
+ * JSON.stringify escapes quotes and newlines but NOT the literal "</script>"
+ * sequence, so user-provided fields (e.g. a book synopsis) could close the
+ * inline <script> tag early and open an XSS hole. Escaping every "<" as its
+ * unicode form neutralizes the breakout while keeping the JSON valid.
+ */
+export const serializeJsonLd = (data: unknown): string =>
+  JSON.stringify(data).replace(/</g, '\\u003c');

--- a/src/utils/seo/listSeo.ts
+++ b/src/utils/seo/listSeo.ts
@@ -1,0 +1,90 @@
+import { SITE_NAME } from '../constants/seo';
+import { getGenreLabel, getFormatLabel } from './facets';
+
+/** Normalized, validated facets as they arrive from getServerSideProps. */
+export interface ListFacets {
+  /** Valid genre slug, or null when absent. */
+  genre: string | null;
+  /** Valid format value, or null when absent. */
+  format: string | null;
+  /** Current page (>= 1). Page 1 is normalized away from the URL upstream. */
+  page: number;
+}
+
+/**
+ * Indexing decision for a listing view, computed on the server so the emitted
+ * robots tag matches what a crawler fetching the raw HTML sees.
+ *
+ * Policy (S4):
+ *  - 0 or 1 active facet AND totalElements > 0 → indexable, self-canonical.
+ *  - 2 active facets OR empty results          → noindex, follow.
+ * "Active facet" counts present facets among { genre, format }.
+ */
+export interface ListIndexing {
+  indexable: boolean;
+}
+
+export const getActiveFacetCount = (facets: ListFacets): number =>
+  (facets.genre ? 1 : 0) + (facets.format ? 1 : 0);
+
+export const computeListIndexing = (
+  facets: ListFacets,
+  totalElements: number,
+): ListIndexing => {
+  const activeFacets = getActiveFacetCount(facets);
+  // Two combined facets slice the catalogue too thin to be worth indexing as a
+  // landing page, and an empty result set is a dead-end for search — both stay
+  // out of the index but keep `follow` so link equity still flows through.
+  const indexable = activeFacets <= 1 && totalElements > 0;
+  return { indexable };
+};
+
+/**
+ * Unique <title> per facet combination, in Spanish (the indexable locale).
+ * A page > 1 gets a " (página N)" suffix so paginated URLs stay self-canonical
+ * without colliding titles.
+ */
+export const buildListTitle = (facets: ListFacets): string => {
+  const genreLabel = facets.genre ? getGenreLabel(facets.genre, 'es') : undefined;
+  const formatLabel = facets.format ? getFormatLabel(facets.format, 'es') : undefined;
+
+  let base: string;
+  if (genreLabel) {
+    base = `Libros de ${genreLabel} para reseñar`;
+  } else if (formatLabel) {
+    base = `Libros en ${formatLabel} para reseñar`;
+  } else {
+    base = 'Libros para reseñar';
+  }
+
+  const paged = facets.page > 1 ? `${base} (página ${facets.page})` : base;
+  return `${paged} | ${SITE_NAME}`;
+};
+
+/** Meta description per facet combination, mirroring the title's facet logic. */
+export const buildListDescription = (facets: ListFacets): string => {
+  const genreLabel = facets.genre ? getGenreLabel(facets.genre, 'es') : undefined;
+  const formatLabel = facets.format ? getFormatLabel(facets.format, 'es') : undefined;
+
+  if (genreLabel) {
+    return `Encuentra libros de ${genreLabel} gratis para reseñar en tu blog, booktube o bookstagram. Pide tu ejemplar en ${SITE_NAME}.`;
+  }
+  if (formatLabel) {
+    return `Encuentra libros en ${formatLabel} gratis para reseñar en tu blog, booktube o bookstagram. Pide tu ejemplar en ${SITE_NAME}.`;
+  }
+  return 'Encuentra libros gratis para reseñar en tu blog, booktube o bookstagram. Filtra por género y formato y elige tu próxima lectura en Reseñan Sancho.';
+};
+
+/**
+ * Canonical/current path for the listing, with a DETERMINISTIC param order
+ * (genre, format, page) so the self-canonical URL is stable regardless of the
+ * order params arrived in. Page 1 is never emitted (normalized upstream).
+ */
+export const buildListPath = (facets: ListFacets): string => {
+  const params: string[] = [];
+  if (facets.genre) params.push(`genre=${facets.genre}`);
+  if (facets.format) params.push(`format=${facets.format}`);
+  if (facets.page > 1) params.push(`page=${facets.page}`);
+
+  return params.length > 0 ? `/books?${params.join('&')}` : '/books';
+};

--- a/src/views/BooksPage/index.test.tsx
+++ b/src/views/BooksPage/index.test.tsx
@@ -38,6 +38,21 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
+// next/router: the view syncs applied facets into the URL via
+// `router.push(..., { shallow: true })`. Without a mounted router `useRouter`
+// throws "NextRouter was not mounted", so supply a router shape with a `push`
+// spy — same precedent as BookDetailCTA/MyBooksSection. The spy is hoisted
+// (jest allows out-of-scope refs prefixed with `mock`) so tests can assert the
+// URL-sync contract; it's reset per test in `beforeEach`.
+const mockRouterPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/books',
+    query: {},
+    push: mockRouterPush,
+  }),
+}));
+
 // ─── Fetch mock helpers ─────────────────────────────────────────────────────
 
 /** Shape returned by the real /books endpoint. Empty `books` keeps card
@@ -111,9 +126,24 @@ describe('BooksPage — fetch/filter contract', () => {
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
 
     await user.selectOptions(screen.getByLabelText(/género literario/i), 'ADV');
+
+    // Applying resets the URL-sync spy count to isolate the push caused by the
+    // click from the mount push, so the "once per applied change" contract is
+    // asserted cleanly.
+    mockRouterPush.mockClear();
     await user.click(screen.getByRole('button', { name: /filtrar libros/i }));
 
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+
+    // URL-sync contract: applying facets shallow-routes exactly once with the
+    // public query — genre CODE (ADV) mapped to its SLUG (aventura), page 1
+    // dropped from the URL.
+    expect(mockRouterPush).toHaveBeenCalledTimes(1);
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      { pathname: '/books', query: { genre: 'aventura' } },
+      undefined,
+      { shallow: true },
+    );
   });
 
   it('resets to page 1 when filtering from a later page, and highlights page 1 again', async () => {

--- a/src/views/BooksPage/index.tsx
+++ b/src/views/BooksPage/index.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import {
   useBooksListFetch,
@@ -7,6 +8,9 @@ import {
 } from '../../utils/customHooks';
 import genresList from '../../utils/constants/genres';
 import formatsList from '../../utils/constants/formats';
+import { genreSlugToCode, genreCodeToSlug } from '../../utils/seo/facets';
+import { ListFacets } from '../../utils/seo/listSeo';
+import { GetBooksResult } from '../../utils/seo/getBooks';
 import EmptyState from '../../components/EmptyState';
 import PageHeader from '../../components/PageHeader';
 import SearchFilters from './SearchFilters';
@@ -77,26 +81,96 @@ const EmptyBookIcon: React.FC = () => (
 // formatsList is an array of enum values (strings), so we can use it directly
 const FORMATS: string[] = formatsList as unknown as string[];
 
+// ─── SSR seeding helpers ─────────────────────────────────────────────────────
+
+/**
+ * Turns URL facets (public slugs) into the draft/applied filter values the
+ * filter selects expect. The genre select is keyed by the internal DB CODE
+ * (see SearchFilters), so the slug is mapped back to its code here; the format
+ * value is already the DB value. Empty keys are dropped so buildQueryString and
+ * the "no filter" API semantics keep working.
+ */
+const facetsToFilterValues = (facets?: ListFacets): Record<string, string> => {
+  if (!facets) return {};
+  const values: Record<string, string> = {};
+  const genreCode = facets.genre ? genreSlugToCode(facets.genre) : undefined;
+  if (genreCode) values.genre = genreCode;
+  if (facets.format) values.format = facets.format;
+  return values;
+};
+
+/**
+ * Reverse of facetsToFilterValues for the URL: internal filter values (genre
+ * CODE, format value) → the query params that make up the public, indexable
+ * URL (genre SLUG, format value). Param order is fixed (genre, format, page) so
+ * the shallow-routed URL matches the server's canonical ordering.
+ */
+const buildListQuery = (
+  values: Record<string, string>,
+  page: number,
+): Record<string, string> => {
+  const query: Record<string, string> = {};
+  const genreSlug = values.genre ? genreCodeToSlug(values.genre) : undefined;
+  if (genreSlug) query.genre = genreSlug;
+  if (values.format) query.format = values.format;
+  if (page > 1) query.page = String(page);
+  return query;
+};
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+interface BooksPageProps {
+  /** URL-derived facets from SSR. Absent when rendered without server props. */
+  initialFacets?: ListFacets;
+  /** Server-fetched first page so the initial paint shows real data. */
+  initialData?: GetBooksResult;
+}
+
 // ─── Component ─────────────────────────────────────────────────────────────
 
-const BooksPage: React.FC = () => {
+const BooksPage: React.FC<BooksPageProps> = ({ initialFacets, initialData }) => {
+  const router = useRouter();
+  const hasSsrData = Boolean(initialData);
+
   const {
     draftFilters,
     setDraftFilter,
     appliedFilters,
     applyFilters,
     goToPage,
-  } = useListFilters();
-  const [state, listRequest, loading] = useBooksListFetch();
+  } = useListFilters(facetsToFilterValues(initialFacets));
+
+  const [state, listRequest, loading] = useBooksListFetch(initialData);
   const currentPage = appliedFilters.page;
   const resultsSectionRef = useScrollToTopOnPageChange<HTMLDivElement>(currentPage);
 
+  // Skip the client fetch that would otherwise duplicate the SSR fetch on first
+  // paint. Only the mount run is skipped; every later `appliedFilters` change
+  // (filter apply, pagination) still fetches. When there is no SSR data (e.g.
+  // the standalone unit test), fetch on mount as before.
+  const didMount = useRef(false);
+
   // The applied filters are the only trigger for a request: pressing "Filtrar"
   // or changing page produces a new object here and this effect fetches once.
-  // `listRequest` is intentionally out of the deps — the hook returns a new
-  // function on every render, so including it would fetch in a loop.
+  // `listRequest`/`router` are intentionally out of the deps — including a
+  // value that changes every render would fetch in a loop.
   useEffect(() => {
+    if (!didMount.current) {
+      didMount.current = true;
+      // With SSR data already in state, don't refetch the identical first page.
+      if (hasSsrData) return;
+    }
+
     listRequest({ ...appliedFilters.values, page: appliedFilters.page });
+
+    // Reflect the applied filters in the URL (public slugs, deterministic order)
+    // without re-running getServerSideProps. Shallow keeps the SSR data path for
+    // real navigations/crawlers while the SPA handles in-page filtering.
+    const listQuery = buildListQuery(appliedFilters.values, appliedFilters.page);
+    router.push({ pathname: '/books', query: listQuery }, undefined, {
+      shallow: true,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appliedFilters]);
 
   const isEmpty = !loading && state.books.length === 0;


### PR DESCRIPTION
## Qué hace (Fase S4 del plan SEO — solo libros)

Convierte el listado de libros en **server-rendered** con facetas de género/formato **indexables por URL**, un **sitemap dinámico** y datos estructurados en la home. Hasta ahora `/books` era 100% cliente (contenido invisible para crawlers) y los filtros vivían en estado local (sin URL).

> Alcance: **solo `/books`**. El listado de reseñadores (`/reviewers`) se aborda en un follow-up (no tiene páginas de detalle).

### Cambios
- **`/books` con `getServerSideProps`**: primera página renderizada en el servidor. Filtros y paginación pasan a la URL (`?genre=&format=&page=`), leídos en el servidor y sincronizados en cliente con `router.push` **shallow** (la SPA sigue filtrando sin recargar; los crawlers y los enlaces directos reciben SSR).
- **Slugs SEO en español** mapeados a los códigos de la BD (`romantica→ROM`, `ciencia-ficcion→CIF`, `novela-historica→HIF`…); formatos usados tal cual (`papel/epub/mobi/pdf/audiolibro`). Fuente única de verdad en `src/utils/seo/facets.ts`.
- **Política de indexación** (en `<Seo>`):
  - 0 o 1 faceta activa **con resultados** → indexable, **self-canonical**, title/description únicos por faceta (p. ej. *"Libros de romántica para reseñar | Reseñan Sancho"*; `page>1` añade *"(página N)"*).
  - 2+ facetas **o** resultado vacío → `noindex, follow`.
  - `?page=1/0/negativo/no-numérico` → **301** a la ruta limpia; slug desconocido → **404**.
- **Robustez SEO ante fallos de API**: si la API falla (red/HTTP/parse), `getBooks` lo señaliza (`ok:false`) y la página responde **503 + `no-store`** — así un fallo transitorio **no** cachea un `noindex` que tiraría la página del índice. El caso legítimo *faceta válida sin resultados* sigue siendo 200 `noindex,follow`.
- **Sitemap dinámico** (`/sitemap.xml`): emite las URLs de detalle `/books/<id>` y las URLs de faceta de página 1 (`/books?genre=<slug>`, `/books?format=<valor>`) **solo** para facetas con resultados. Con tope de páginas de seguridad, `escapeXml` defensivo y fallback a rutas estáticas si la API falla.
- **Datos estructurados en la home**: JSON-LD `WebSite` + `Organization` (sin `SearchAction`, porque no hay búsqueda de texto libre).
- Extraído `getBooks({genre,format,page})` reutilizable (las futuras landing de género lo envolverán) y `serializeJsonLd` compartido (endurecido contra `</script>`), ahora también usado por `/books/[id]`.

### Pipeline
Implementación (`senior-frontend`) → revisión (`frontend-reviewer`, **sin bloqueantes**) → correcciones recomendadas aplicadas → re-verificación. `npm run build` compila limpio (`/books`, `/books/[id]` y `/sitemap.xml` como `ƒ`/SSR); **suite completa 119/119 verde** (incluye el mock de router y el contrato de sincronización de URL en `BooksPage`).

## Verificación manual realizada
Probado contra la API real: `/books` con datos en el HTML de servidor; `?genre=romantica` indexable y self-canonical; 2 facetas → `noindex,follow`; slug inventado → 404; `?page=1` → 301; `?book=<id>` legacy → 301 a `/books/<id>`; filtrado/paginación en cliente actualizan la URL sin recarga; sitemap válido con URLs de libros y facetas; JSON-LD de home presente; flujo listado → detalle → modal de contacto/pedido OK.

## Versión
Bump **1.6.1 → 1.7.0** (MINOR: nueva capacidad).

## Notas / deuda conocida (no bloqueante)
- `page>1` es indexable + self-canonical por decisión de diseño (vigilar thin content en catálogos pequeños).
- `crimen` y `policiaca` son facetas próximas semánticamente (nota de estrategia de contenidos).
- Confirmar que la API respeta `size` en el volcado del sitemap para catálogos grandes (hay fallback por paginación con tope).
- `s-maxage` solo aplica si hay CDN/proxy delante de Heroku (inocuo si no).

🤖 Generated with [Claude Code](https://claude.com/claude-code)